### PR TITLE
(fix)RadioGroup: Size prop mismatch, configure style

### DIFF
--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -61,7 +61,7 @@ class Checkbox extends React.Component {
     color: PropTypes.string,
     horizontal: PropTypes.bool,
     disabled: PropTypes.bool,
-    styles: PropTypes.object,
+    styles: PropTypes.shape(),
   };
 
   static defaultProps = {

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -145,7 +145,7 @@ class Checkbox extends React.Component {
         <Flex alignItems="center">
           <StyledIcon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
-          {label && <StyledLabel fontSize={fontSize}>{label}</StyledLabel>}
+          {label && <StyledLabel fontSize={fontSize} style={styles.Label}>{label}</StyledLabel>}
         </Flex>
 
         {!this.state.focused && error ? <FormError>{error}</FormError> : null}

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -19,6 +19,7 @@ const CheckboxContainer = createComponent({
       margin-left: ${p => (p.horizontal ? '12px' : 0)};
       margin-top: ${p => (p.horizontal ? 0 : '4px')};
     }
+    ${p => p.style}
   `,
 });
 
@@ -28,14 +29,6 @@ const StyledInput = createComponent({
   style: css`
     display: none;
     pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
-  `,
-});
-
-const StyledIcon = createComponent({
-  name: 'CheckboxIcon',
-  as: Icon,
-  style: ({ margin }) => css`
-    margin: ${margin};
   `,
 });
 
@@ -64,6 +57,7 @@ class Checkbox extends React.Component {
     color: PropTypes.string,
     horizontal: PropTypes.bool,
     disabled: PropTypes.bool,
+    styles: PropTypes.object,
   };
 
   static defaultProps = {
@@ -78,6 +72,7 @@ class Checkbox extends React.Component {
     horizontal: false,
     onChange() {},
     disabled: false,
+    styles: {},
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -123,16 +118,16 @@ class Checkbox extends React.Component {
       iconOn,
       iconOff,
       iconSize,
-      iconMargin,
       colorOn,
       colorOff,
       horizontal,
       disabled,
+      styles,
     } = this.props;
     const { checked } = this;
 
     return (
-      <CheckboxContainer horizontal={horizontal}>
+      <CheckboxContainer horizontal={horizontal} style={styles.CheckboxContainer}>
         <StyledInput
           id={id}
           name={name}
@@ -143,7 +138,7 @@ class Checkbox extends React.Component {
         />
 
         <Flex alignItems="center">
-          <StyledIcon margin={iconMargin} size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
+          <Icon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
           {label && <StyledLabel fontSize={fontSize}>{label}</StyledLabel>}
         </Flex>

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -32,6 +32,11 @@ const StyledInput = createComponent({
   `,
 });
 
+const StyledIcon = createComponent({
+  name: 'CheckboxIcon',
+  as: Icon,
+});
+
 const StyledLabel = createComponent({
   name: 'CheckboxLabel',
   as: Flex,
@@ -138,7 +143,7 @@ class Checkbox extends React.Component {
         />
 
         <Flex alignItems="center">
-          <Icon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
+          <StyledIcon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
           {label && <StyledLabel fontSize={fontSize}>{label}</StyledLabel>}
         </Flex>

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -34,6 +34,9 @@ const StyledInput = createComponent({
 const StyledIcon = createComponent({
   name: 'CheckboxIcon',
   as: Icon,
+  style: ({ margin }) => css`
+    margin: ${margin};
+  `,
 });
 
 const StyledLabel = createComponent({
@@ -120,6 +123,7 @@ class Checkbox extends React.Component {
       iconOn,
       iconOff,
       iconSize,
+      iconMargin,
       colorOn,
       colorOff,
       horizontal,
@@ -139,7 +143,7 @@ class Checkbox extends React.Component {
         />
 
         <Flex alignItems="center">
-          <StyledIcon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
+          <StyledIcon margin={iconMargin} size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
           {label && <StyledLabel fontSize={fontSize}>{label}</StyledLabel>}
         </Flex>

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -19,7 +19,6 @@ const CheckboxContainer = createComponent({
       margin-left: ${p => (p.horizontal ? '12px' : 0)};
       margin-top: ${p => (p.horizontal ? 0 : '4px')};
     }
-    ${p => p.style}
   `,
 });
 

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -103,7 +103,7 @@ Form Radio component. Both font and icon sizes are configurable.
       },
     ];
     return (
-      <RadioGroup iconSize={10} fontSize={10} iconMargin={10} name="radio" id="radio" choices={radioValues} value='radio2' />
+      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} value='radio2' styles={{CheckboxContainer: { margin: '0 !important'}}} />
     )
   }}
 </Playground>

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -8,7 +8,7 @@ import RadioGroup from './RadioGroup'
 
 # Radio
 
-Form Radio component. Different sizes are available.
+Form Radio component. Both font and icon sizes are configurable.
 
 ## Props
 

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -103,7 +103,7 @@ Form Radio component. Both font and icon sizes are configurable.
       },
     ];
     return (
-      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} styles={{ CheckboxContainer: { margin: '0 !important'}, Label: { marginLeft: 6 } }} />
+      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} styles={{ CheckboxContainer: { margin: 0 }, Label: { marginLeft: 6 } }} />
     )
   }}
 </Playground>

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -84,3 +84,26 @@ Form Radio component. Both font and icon sizes are configurable.
     )
   }}
 </Playground>
+
+### Radio Group sizes
+<Playground>
+  {() => {
+    const radioValues = [
+      {
+        id: 1,
+        value: 'radio1',
+        name: 'radio1',
+        label: 'Radio 1',
+      },
+      {
+        id: 2,
+        value: 'radio2',
+        name: 'radio2',
+        label: 'Radio 2',
+      },
+    ];
+    return (
+      <RadioGroup iconSize={10} fontSize={10} iconMargin={10} name="radio" id="radio" choices={radioValues} value='radio2' />
+    )
+  }}
+</Playground>

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -103,7 +103,7 @@ Form Radio component. Both font and icon sizes are configurable.
       },
     ];
     return (
-      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} styles={{CheckboxContainer: { margin: '0 !important'}}} />
+      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} styles={{ CheckboxContainer: { margin: '0 !important'}, Label: { marginLeft: 6 } }} />
     )
   }}
 </Playground>

--- a/src/Form/Radio.mdx
+++ b/src/Form/Radio.mdx
@@ -103,7 +103,7 @@ Form Radio component. Both font and icon sizes are configurable.
       },
     ];
     return (
-      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} value='radio2' styles={{CheckboxContainer: { margin: '0 !important'}}} />
+      <RadioGroup iconSize={10} fontSize={10} name="radio" id="radio" choices={radioValues} styles={{CheckboxContainer: { margin: '0 !important'}}} />
     )
   }}
 </Playground>

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -22,7 +22,6 @@ class RadioGroup extends Component {
     colorOn: PropTypes.string,
     colorOff: PropTypes.string,
     fontSize: PropTypes.number,
-    iconMargin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     iconSize: PropTypes.number,
     choices: PropTypes.arrayOf(
       PropTypes.shape({
@@ -31,11 +30,13 @@ class RadioGroup extends Component {
         disabled: PropTypes.bool,
       })
     ),
+    styles: PropTypes.object,
   };
 
   static defaultProps = {
     choices: [],
     onChange() {},
+    styles: {},
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -62,7 +63,7 @@ class RadioGroup extends Component {
   };
 
   render() {
-    const { choices, error, horizontal, label, name, colorOn, colorOff, fontSize, iconSize, iconMargin } = this.props;
+    const { choices, error, horizontal, label, name, colorOn, colorOff, fontSize, iconSize, styles } = this.props;
 
     return (
       <StyledRadioGroup>
@@ -90,8 +91,8 @@ class RadioGroup extends Component {
                   iconOn="radiobox-marked"
                   iconOff="radiobox-blank"
                   iconSize={iconSize}
-                  iconMargin={iconMargin}
                   onChange={this.handleChange}
+                  styles={styles}
                 />
               );
             })}

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -21,7 +21,9 @@ class RadioGroup extends Component {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     colorOn: PropTypes.string,
     colorOff: PropTypes.string,
-    size: PropTypes.string,
+    fontSize: PropTypes.number,
+    iconMargin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    iconSize: PropTypes.number,
     choices: PropTypes.arrayOf(
       PropTypes.shape({
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { css } from 'styled-components';
 import Flex from '../Flex';
 import Box from '../Box';
 import Checkbox from './Checkbox';
@@ -33,7 +34,6 @@ class RadioGroup extends Component {
   static defaultProps = {
     choices: [],
     onChange() {},
-    size: 'md',
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -60,7 +60,7 @@ class RadioGroup extends Component {
   };
 
   render() {
-    const { choices, error, horizontal, label, name, colorOn, colorOff, size } = this.props;
+    const { choices, error, horizontal, label, name, colorOn, colorOff, fontSize, iconSize, iconMargin } = this.props;
 
     return (
       <StyledRadioGroup>
@@ -78,7 +78,7 @@ class RadioGroup extends Component {
                   key={key}
                   name={key}
                   horizontal={horizontal}
-                  size={size}
+                  fontSize={fontSize}
                   colorOn={colorOn}
                   colorOff={colorOff}
                   label={choiceLabel}
@@ -87,6 +87,8 @@ class RadioGroup extends Component {
                   valueFalse={value}
                   iconOn="radiobox-marked"
                   iconOff="radiobox-blank"
+                  iconSize={iconSize}
+                  iconMargin={iconMargin}
                   onChange={this.handleChange}
                 />
               );

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -31,12 +31,16 @@ class RadioGroup extends Component {
       })
     ),
     styles: PropTypes.object,
+    iconOn: PropTypes.string,
+    iconOf: PropTypes.string,
   };
 
   static defaultProps = {
     choices: [],
     onChange() {},
     styles: {},
+    iconOn: 'radiobox-marked',
+    iconOff: 'radiobox-blank',
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -63,7 +67,7 @@ class RadioGroup extends Component {
   };
 
   render() {
-    const { choices, error, horizontal, label, name, colorOn, colorOff, fontSize, iconSize, styles } = this.props;
+    const { choices, error, horizontal, label, name, colorOn, colorOff, ...checkboxProps } = this.props;
 
     return (
       <StyledRadioGroup>
@@ -77,22 +81,18 @@ class RadioGroup extends Component {
 
               return (
                 <Checkbox
+                  {...checkboxProps}
                   id={key}
                   key={key}
                   name={key}
                   horizontal={horizontal}
-                  fontSize={fontSize}
                   colorOn={colorOn}
                   colorOff={colorOff}
                   label={choiceLabel}
                   value={this.state.value}
                   valueTrue={value}
                   valueFalse={value}
-                  iconOn="radiobox-marked"
-                  iconOff="radiobox-blank"
-                  iconSize={iconSize}
                   onChange={this.handleChange}
-                  styles={styles}
                 />
               );
             })}

--- a/src/Form/RadioGroup.js
+++ b/src/Form/RadioGroup.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { css } from 'styled-components';
 import Flex from '../Flex';
 import Box from '../Box';
 import Checkbox from './Checkbox';
@@ -30,9 +29,9 @@ class RadioGroup extends Component {
         disabled: PropTypes.bool,
       })
     ),
-    styles: PropTypes.object,
+    styles: PropTypes.shape(),
     iconOn: PropTypes.string,
-    iconOf: PropTypes.string,
+    iconOff: PropTypes.string,
   };
 
   static defaultProps = {
@@ -67,7 +66,7 @@ class RadioGroup extends Component {
   };
 
   render() {
-    const { choices, error, horizontal, label, name, colorOn, colorOff, ...checkboxProps } = this.props;
+    const { choices, error, horizontal, label, name, ...checkboxProps } = this.props;
 
     return (
       <StyledRadioGroup>
@@ -86,8 +85,6 @@ class RadioGroup extends Component {
                   key={key}
                   name={key}
                   horizontal={horizontal}
-                  colorOn={colorOn}
-                  colorOff={colorOff}
                   label={choiceLabel}
                   value={this.state.value}
                   valueTrue={value}


### PR DESCRIPTION
These changes fix a bug where `<RadioGroup/>` accepted a `size` (string) prop, but it's child component `<Checkbox/>` only accepted `iconSize` (number), and `fontSize` (number). Also styles are now passed down to support more customization (margins, etc.), such as required by [EMR Message Conversation List](https://app.asana.com/0/821652619613450/1108680987294666/f).

![image](https://user-images.githubusercontent.com/16051172/54451152-6a98ef80-470f-11e9-9fcf-d50d2efe7dfe.png)
