### PR TITLE
fix(Input): allow forwardedRef to be a function

### DIFF
--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -94,7 +94,7 @@ class Input extends Component {
     autogrow: PropTypes.bool,
     size: PropTypes.string,
     floating: PropTypes.bool,
-    forwardedRef: PropTypes.shape(),
+    forwardedRef: PropTypes.oneOfType([PropTypes.shape(). PropTypes.func]),
   };
 
   static defaultProps = {


### PR DESCRIPTION
fixes warning when supplying a ref setter function
```
Warning: Failed prop type: Invalid prop `forwardedRef` of type `function` supplied to `Input`, expected `object`.
    in Input
    in Unknown (created by EasyInput)
    in EasyInput (created by ForwardRef)
```