### PR TITLE
(fix)Dropdown: Configure <Dropdown.Trigger/> style

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -28,7 +28,7 @@ export const PLACEMENT_TRANSITION_ORIGINS = {
 
 const ARROW_KEYS = ['ArrowUp', 'ArrowDown'];
 
-const TriggerWrapper = createComponent({
+const Trigger = createComponent({
   name: 'DropdownTrigger',
   style: css`
     align-self: flex-start;
@@ -115,7 +115,7 @@ export default function Dropdown({
       <Manager>
         <Reference>
           {({ ref: triggerRef }) => (
-            <TriggerWrapper style={styles.TriggerWrapper} ref={triggerRef} tabIndex={-1}>
+            <Trigger style={styles.Trigger} ref={triggerRef} tabIndex={-1}>
               {React.cloneElement(trigger, {
                 role: trigger.role || 'button',
                 tabIndex: trigger.tabIndex || 0,
@@ -128,7 +128,7 @@ export default function Dropdown({
                   ...(trigger.style || {}),
                 },
               })}
-            </TriggerWrapper>
+            </Trigger>
           )}
         </Reference>
 

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -31,8 +31,8 @@ const ARROW_KEYS = ['ArrowUp', 'ArrowDown'];
 const TriggerWrapper = createComponent({
   name: 'DropdownTrigger',
   style: css`
-    display: inline-block;
     align-self: flex-start;
+    display: inline-block;
     outline: none;
   `,
 });
@@ -47,6 +47,7 @@ export default function Dropdown({
   render,
   children,
   portalNode,
+  styles = {},
   ...menuProps
 }) {
   const popperRef = useRef();
@@ -114,7 +115,7 @@ export default function Dropdown({
       <Manager>
         <Reference>
           {({ ref: triggerRef }) => (
-            <TriggerWrapper ref={triggerRef} tabIndex={-1}>
+            <TriggerWrapper style={styles.TriggerWrapper} ref={triggerRef} tabIndex={-1}>
               {React.cloneElement(trigger, {
                 role: trigger.role || 'button',
                 tabIndex: trigger.tabIndex || 0,

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -18,7 +18,7 @@ Easily display contextual overlays using custom trigger elements. Dropdown's pos
 ## Props
 <PropsTable of={Dropdown} />
 
-## Example
+## Examples
 
 <Playground>
   {() => {
@@ -99,8 +99,9 @@ Easily display contextual overlays using custom trigger elements. Dropdown's pos
                 width={250}
                 placement="top"
                 styles={{ TriggerWrapper: { display: 'flex', flex: 1 } }}
-		trigger={<Flex flex={1} justifyContent="space-between" ><Button style={{ width: `100%`}}>Open Flex Dropdown</Button> </Flex>}
-              >
+                trigger={(<Flex flex={1} justifyContent="space-between">
+                  <Button style={{ width: `100%`}}>Open Flex Dropdown</Button>
+                </Flex>)}>
                 <Dropdown.Header title="Dropdown" />
 
                 <Dropdown.Body>

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -98,7 +98,7 @@ Easily display contextual overlays using custom trigger elements. Dropdown's pos
               <Dropdown
                 width={250}
                 placement="top"
-                styles={{ TriggerWrapper: { display: 'flex', flex: 1 } }}
+                styles={{ Trigger: { display: 'flex', flex: 1 } }}
                 trigger={(<Flex flex={1} justifyContent="space-between">
                   <Button style={{ width: `100%`}}>Open Flex Dropdown</Button>
                 </Flex>)}>

--- a/src/Dropdown/Dropdown.mdx
+++ b/src/Dropdown/Dropdown.mdx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { Playground, PropsTable } from 'docz';
 import Dropdown, { PLACEMENT_TRANSITION_ORIGINS } from './Dropdown';
 import Icon from '../Icon';
+import Flex from '../Flex';
 import RadioGroup from '../Form/RadioGroup';
 import Button from '../Button';
 
@@ -92,6 +93,25 @@ Easily display contextual overlays using custom trigger elements. Dropdown's pos
                 <Dropdown.Footer>Footer</Dropdown.Footer>
               </Dropdown>
             </div>
+
+            <Flex flex={1}>
+              <Dropdown
+                width={250}
+                placement="top"
+                styles={{ TriggerWrapper: { display: 'flex', flex: 1 } }}
+		trigger={<Flex flex={1} justifyContent="space-between" ><Button style={{ width: `100%`}}>Open Flex Dropdown</Button> </Flex>}
+              >
+                <Dropdown.Header title="Dropdown" />
+
+                <Dropdown.Body>
+                  <Dropdown.SectionTitle>Section One</Dropdown.SectionTitle>
+                  <Dropdown.Item>Item One</Dropdown.Item>
+                  <Dropdown.Item>Item Two</Dropdown.Item>
+                </Dropdown.Body>
+
+                <Dropdown.Footer>Footer</Dropdown.Footer>
+              </Dropdown>
+            </Flex>
           </Button.Group>
         </>
       );

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -3,10 +3,10 @@
 exports[`<Dropdown /> only renders trigger on mount 1`] = `
 <DocumentFragment>
   .c0 {
-  display: inline-block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+  display: inline-block;
   outline: none;
 }
 
@@ -67,10 +67,10 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
 exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
 <DocumentFragment>
   .c0 {
-  display: inline-block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
+  display: inline-block;
   outline: none;
 }
 


### PR DESCRIPTION
These changes allow the `<Dropdown/>` component's `<TriggerWrapper/>`(`styled(Dropdown.Trigger)`) to be styled so that it may, for example, fill the available width of its parent container.
![image](https://user-images.githubusercontent.com/16051172/54846805-ed82f280-4c99-11e9-8e11-0e69e0791b64.png)

