### PR TITLE
fix(Icon): Prevent passed className from being overwritten

### DIFF
--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -30,7 +30,7 @@ Card.Header = createComponent({
   as: Box,
   style: ({ theme }) => css`
     padding: 1rem;
-    border-bottom: 1px solid ${theme.colors.grayLight}};
+    border-bottom: 1px solid ${theme.colors.grayLight};
   `,
 });
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -6,7 +6,7 @@ const Icon = createComponent({
   name: 'Icon',
   tag: 'i',
   props: ({ name }) => ({
-    baseClassName: Icon.getClassName(name),
+    className: Icon.getClassName(name),
   }),
   style: ({ theme, size, color, disabled }) => {
     const colorFromTheme = theme.colors[color];

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -6,7 +6,7 @@ const Icon = createComponent({
   name: 'Icon',
   tag: 'i',
   props: ({ name }) => ({
-    passedClassName: Icon.getClassName(name),
+    baseClassName: Icon.getClassName(name),
   }),
   style: ({ theme, size, color, disabled }) => {
     const colorFromTheme = theme.colors[color];

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -5,8 +5,8 @@ import { createComponent } from '../utils';
 const Icon = createComponent({
   name: 'Icon',
   tag: 'i',
-  props: ({ name, className }) => ({
-    className: `${Icon.getClassName(name)} ${className || ''}`,
+  props: ({ name }) => ({
+    passedClassName: Icon.getClassName(name),
   }),
   style: ({ theme, size, color, disabled }) => {
     const colorFromTheme = theme.colors[color];

--- a/src/Icon/Icon.spec.js
+++ b/src/Icon/Icon.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { renderWithTheme } from '../../test/utils';
+import Icon from './Icon';
+
+describe('<Icon />', () => {
+  test('renders', () => {
+    const { asFragment } = renderWithTheme(<Icon name="message" />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('renders with passed class name', () => {
+    const { asFragment } = renderWithTheme(<Icon className="bagels" name="message" />);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/Icon/__snapshots__/Icon.spec.js.snap
+++ b/src/Icon/__snapshots__/Icon.spec.js.snap
@@ -22,7 +22,7 @@ exports[`<Icon /> renders with passed class name 1`] = `
 }
 
 <i
-    class="bagels bagels mdi mdi-message re-icon c0"
+    class="bagels mdi mdi-message re-icon c0"
     name="message"
   />
 </DocumentFragment>

--- a/src/Icon/__snapshots__/Icon.spec.js.snap
+++ b/src/Icon/__snapshots__/Icon.spec.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Icon /> renders 1`] = `
+<DocumentFragment>
+  .c0 {
+  color: inherit;
+  font-size: inherit;
+}
+
+<i
+    class="mdi mdi-message re-icon c0"
+    name="message"
+  />
+</DocumentFragment>
+`;
+
+exports[`<Icon /> renders with passed class name 1`] = `
+<DocumentFragment>
+  .c0 {
+  color: inherit;
+  font-size: inherit;
+}
+
+<i
+    class="bagels bagels mdi mdi-message re-icon c0"
+    name="message"
+  />
+</DocumentFragment>
+`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,8 +13,10 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
 
-export const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
-  `${className || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
+export const getComponentClassName = ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
+  `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
+    variant ? `${classPrefix}-${name}-${variant}` : ''
+  }`.trim();
 
 export const createComponent = ({ name, tag = 'div', as, style, props: baseProps = () => ({}) }) => {
   const component = as ? styled(as) : styled[tag];

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,22 +13,22 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
 
-const getComponentClassName = ({ baseClassName, theme: { classPrefix }, variant }, name) =>
-  `${baseClassName || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
+const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
+  `${className || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
 
-export const createComponent = ({ name, tag = 'div', as, style, props: baseProps = () => ({}) }) => {
+export const createComponent = ({ name, tag = 'div', as, style, props: getBaseProps = () => ({}) }) => {
   const component = as ? styled(as) : styled[tag];
 
   return component.attrs(props => {
-    const resolvedProps = { ...baseProps(props), ...props };
-
+    const baseProps = getBaseProps(props);
     const finalProps = {
-      ...resolvedProps,
-      baseClassName: get(resolvedProps, 'baseClassName', props.className),
+      ...props,
+      ...baseProps,
+      className: baseProps.className || props.className,
     };
 
     return {
-      ...resolvedProps,
+      ...finalProps,
       className: getComponentClassName(finalProps, kebabCase(name)),
     };
   })`

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { get, kebabCase, flow } from 'lodash';
+import { get, kebabCase } from 'lodash';
 import styled from 'styled-components';
 
 export const themeGet = (lookup, fallback) => ({ theme } = {}) => get(theme, lookup, fallback);
@@ -13,17 +13,13 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
 
-const getComponentClassName = flow(
-  ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
-    `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
-      variant ? `${classPrefix}-${name}-${variant}` : ''
-    }`,
-  string =>
-    string
-      .split(' ')
-      .filter(Boolean)
-      .join(' ')
-);
+const getComponentClassName = ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
+  `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
+    variant ? `${classPrefix}-${name}-${variant}` : ''
+  }`
+    .split(' ')
+    .filter(Boolean)
+    .join(' ');
 
 export const createComponent = ({ name, tag = 'div', as, style, props: baseProps = () => ({}) }) => {
   const component = as ? styled(as) : styled[tag];

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { get, kebabCase } from 'lodash';
+import { get, kebabCase, flow } from 'lodash';
 import styled from 'styled-components';
 
 export const themeGet = (lookup, fallback) => ({ theme } = {}) => get(theme, lookup, fallback);
@@ -13,10 +13,17 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
 
-export const getComponentClassName = ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
-  `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
-    variant ? `${classPrefix}-${name}-${variant}` : ''
-  }`.trim();
+const getComponentClassName = flow(
+  ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
+    `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
+      variant ? `${classPrefix}-${name}-${variant}` : ''
+    }`,
+  string =>
+    string
+      .split(' ')
+      .filter(Boolean)
+      .join(' ')
+);
 
 export const createComponent = ({ name, tag = 'div', as, style, props: baseProps = () => ({}) }) => {
   const component = as ? styled(as) : styled[tag];

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,25 +13,23 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
 
-const getComponentClassName = ({ className, passedClassName, theme: { classPrefix }, variant }, name) =>
-  `${className || ''} ${passedClassName || ''} ${classPrefix}-${name} ${
-    variant ? `${classPrefix}-${name}-${variant}` : ''
-  }`
-    .split(' ')
-    .filter(Boolean)
-    .join(' ');
+const getComponentClassName = ({ baseClassName, theme: { classPrefix }, variant }, name) =>
+  `${baseClassName || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
 
 export const createComponent = ({ name, tag = 'div', as, style, props: baseProps = () => ({}) }) => {
   const component = as ? styled(as) : styled[tag];
 
   return component.attrs(props => {
-    const resolvedProps = {
-      ...baseProps(props),
-      ...props,
+    const resolvedProps = { ...baseProps(props), ...props };
+
+    const finalProps = {
+      ...resolvedProps,
+      baseClassName: get(resolvedProps, 'baseClassName', props.className),
     };
+
     return {
       ...resolvedProps,
-      className: getComponentClassName(resolvedProps, kebabCase(name)),
+      className: getComponentClassName(finalProps, kebabCase(name)),
     };
   })`
     ${style}

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,8 +22,8 @@ export const createComponent = ({ name, tag = 'div', as, style, props: getBasePr
   return component.attrs(props => {
     const baseProps = getBaseProps(props);
     const finalProps = {
-      ...props,
       ...baseProps,
+      ...props,
       className: baseProps.className || props.className,
     };
 


### PR DESCRIPTION
## Summary 
When the `Icon` component was being provided with a `className` prop, this prop was overwriting the default class name generated for the icon, namely `mdi mdi-X`. In the web-app several icons disappeared mysteriously and this was because those component had this structure...
```js
<Icon className="blah" name="message" />
```

...which is explained by this snippet:
```js
<Icon className="bagels" name="message" /> //=> render Icon with className prop

const Icon = createComponent({
  props: () => ({
    className: 'mdi mdi-message', //=> generated by `Icon.getClassName`
  });

// and then inside of `utils#createComponent`
const resolvedProps = {
  ...baseProps(props), //=> className: mdi mdi-message
  ...props, //=> className: overwritten by bagels!!!   
};
```