### PR TITLE
fix(PhoneInput): Cast null to empty string

### DIFF
--- a/src/Form/PhoneInput.js
+++ b/src/Form/PhoneInput.js
@@ -19,8 +19,9 @@ function PhoneInput({ countryCode, forwardedRef, value: propValue, onKeyDown, on
     throw new Error(`${countryCode} is not supported`);
   }
 
-  const format = (value = '') => {
-    const parsed = parseDigits(value).substr(0, getRawMaxLength(countryCode, value));
+  const format = value => {
+    const phoneString = value || '';
+    const parsed = parseDigits(phoneString).substr(0, getRawMaxLength(countryCode, phoneString));
     return new AsYouType(countryCode).input(parsed);
   };
 


### PR DESCRIPTION
Not sure where/how the value is being set to null, so adding this defensive cast until we can dig more

https://sentry.io/organizations/heydoctor/issues/996939211/?environment=beta&project=290802&query=is%3Aunresolved