### PR TITLE
fix(Modal): Lock focus

### DIFF
--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -7,15 +7,10 @@ import Dropdown from '../Dropdown';
 export default class ModalDropdownDemo extends React.Component {
   state = {
     isModalOpen: false,
-    isModalTwoOpen: false,
   };
 
   toggle = () => {
-    this.setState({ isModalOpen: !this.state.isModalOpen, isModalTwoOpen: false });
-  };
-
-  toggleModalTwo = () => {
-    this.setState({ isModalTwoOpen: !this.state.isModalTwoOpen });
+    this.setState({ isModalOpen: !this.state.isModalOpen });
   };
 
   onCancel = () => {

--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -2,8 +2,9 @@ import React from 'react';
 import Modal from './Modal';
 import Button from '../Button';
 import Input from '../Form/Input';
+import Dropdown from '../Dropdown';
 
-export default class ModalDemo extends React.Component {
+export default class ModalDropdownDemo extends React.Component {
   state = {
     isModalOpen: false,
     isModalTwoOpen: false,
@@ -26,52 +27,40 @@ export default class ModalDemo extends React.Component {
   };
 
   render() {
-    const { body, bodyTwo = 'Im a nested modal!', groupId, ...props } = this.props;
+    const { body, groupId, ...props } = this.props;
 
     return (
       <div>
-        <Button onClick={this.toggle}>Open Modal</Button>
+        <Dropdown placement="0 100%" width={250} trigger={<Button variant="success">Open Dropdown</Button>}>
+          <Dropdown.Header title="Dropdown" />
+
+          <Dropdown.Body>
+            <Dropdown.SectionTitle>Section One</Dropdown.SectionTitle>
+            <Dropdown.Item onClick={this.toggle} as="button">
+              Open Modal
+            </Dropdown.Item>
+          </Dropdown.Body>
+
+          <Dropdown.Footer>Footer</Dropdown.Footer>
+        </Dropdown>
 
         <Modal
           groupId={`${groupId}-outer`}
           open={this.state.isModalOpen}
           onClose={this.toggle}
-          title="Example Modal"
+          title="Example Dropdown Modal"
           {...props}>
           <Modal.Body>
             <>
               {body}
               <Input autoFocus name="password" label="Password" />
             </>
-
-            <Modal
-              groupId={`${groupId}-inner`}
-              open={this.state.isModalTwoOpen}
-              onClose={this.toggleModalTwo}
-              title="Example Modal Two"
-              {...props}>
-              <Modal.Body>{bodyTwo}</Modal.Body>
-
-              <Modal.Footer>
-                <Button.Group justifyContent="flex-end">
-                  <Button variant="gray" onClick={this.toggleModalTwo}>
-                    Cancel
-                  </Button>
-                  <Button variant="success" onClick={this.toggleModalTwo}>
-                    I&apos;m Done Anyways
-                  </Button>
-                </Button.Group>
-              </Modal.Footer>
-            </Modal>
           </Modal.Body>
 
           <Modal.Footer>
             <Button.Group justifyContent="flex-end">
               <Button variant="gray" onClick={this.onCancel}>
                 Cancel
-              </Button>
-              <Button variant="success" onClick={this.toggleModalTwo}>
-                Open Another Modal
               </Button>
             </Button.Group>
           </Modal.Footer>

--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -27,7 +27,7 @@ export default class ModalDropdownDemo extends React.Component {
   };
 
   render() {
-    const { body, groupId, ...props } = this.props;
+    const { body, ...props } = this.props;
 
     return (
       <div>
@@ -45,7 +45,6 @@ export default class ModalDropdownDemo extends React.Component {
         </Dropdown>
 
         <Modal
-          groupId={`${groupId}-outer`}
           open={this.state.isModalOpen}
           onClose={this.toggle}
           title="Example Dropdown Modal"

--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -31,7 +31,7 @@ export default class ModalDropdownDemo extends React.Component {
 
     return (
       <div>
-        <Dropdown placement="0 100%" width={250} trigger={<Button variant="success">Open Dropdown</Button>}>
+        <Dropdown placement="top" width={250} trigger={<Button variant="success">Open Dropdown</Button>}>
           <Dropdown.Header title="Dropdown" />
 
           <Dropdown.Body>

--- a/src/Modal/Modal.example.js
+++ b/src/Modal/Modal.example.js
@@ -26,14 +26,13 @@ export default class ModalDemo extends React.Component {
   };
 
   render() {
-    const { body, bodyTwo = 'Im a nested modal!', groupId, ...props } = this.props;
+    const { body, bodyTwo = 'Im a nested modal!', ...props } = this.props;
 
     return (
       <div>
         <Button onClick={this.toggle}>Open Modal</Button>
 
         <Modal
-          groupId={`${groupId}-outer`}
           open={this.state.isModalOpen}
           onClose={this.toggle}
           title="Example Modal"
@@ -45,7 +44,6 @@ export default class ModalDemo extends React.Component {
             </>
 
             <Modal
-              groupId={`${groupId}-inner`}
               open={this.state.isModalTwoOpen}
               onClose={this.toggleModalTwo}
               title="Example Modal Two"

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -106,7 +106,7 @@ function Modal({ children, title, animationDuration, showClose, onClose, open, .
         <Transition in={isOpen} timeout={animationDuration}>
           {state => (
             <Backdrop transitionState={state} onClick={handleBackdropClick}>
-              <FocusLock lockProps={{ style: { height: '100%' } }} disabled={!isOpen}>
+              <FocusLock lockProps={{ style: { maxHeight: '100%' } }} disabled={!isOpen}>
                 <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -106,7 +106,7 @@ function Modal({ children, title, animationDuration, showClose, onClose, open, .
         <Transition in={isOpen} timeout={animationDuration}>
           {state => (
             <Backdrop transitionState={state} onClick={handleBackdropClick}>
-              <FocusLock disabled={!isOpen}>
+              <FocusLock lockProps={{ style: { height: '100%' } }} disabled={!isOpen}>
                 <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -73,7 +73,7 @@ const ModalContent = createComponent({
   `,
 });
 
-function Modal({ groupId, children, title, animationDuration, showClose, onClose, open, ...props }) {
+function Modal({ children, title, animationDuration, showClose, onClose, open, ...props }) {
   const [isOpen, setOpen] = useState(open);
 
   const handleClose = () => {
@@ -106,7 +106,7 @@ function Modal({ groupId, children, title, animationDuration, showClose, onClose
         <Transition in={isOpen} timeout={animationDuration}>
           {state => (
             <Backdrop transitionState={state} onClick={handleBackdropClick}>
-              <FocusLock group={groupId} disabled={!isOpen}>
+              <FocusLock disabled={!isOpen}>
                 <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}
@@ -121,7 +121,6 @@ function Modal({ groupId, children, title, animationDuration, showClose, onClose
 }
 
 Modal.propTypes = {
-  groupId: PropTypes.string.isRequired,
   open: PropTypes.bool,
   showClose: PropTypes.bool,
   closeOnBackdropClick: PropTypes.bool,

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { keyframes, css } from 'styled-components';
 import * as animations from 'react-animations';
 import { Transition } from 'react-transition-group';
+import FocusLock from 'react-focus-lock';
 import Portal from '../Portal';
 import Flex from '../Flex';
 import Box from '../Box';
@@ -72,7 +73,7 @@ const ModalContent = createComponent({
   `,
 });
 
-function Modal({ children, title, animationDuration, showClose, onClose, open, ...props }) {
+function Modal({ groupId, children, title, animationDuration, showClose, onClose, open, ...props }) {
   const [isOpen, setOpen] = useState(open);
 
   const handleClose = () => {
@@ -105,10 +106,12 @@ function Modal({ children, title, animationDuration, showClose, onClose, open, .
         <Transition in={isOpen} timeout={animationDuration}>
           {state => (
             <Backdrop transitionState={state} onClick={handleBackdropClick}>
-              <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
-                {title && <Modal.Header title={title} showClose={showClose} />}
-                {children}
-              </ModalContent>
+              <FocusLock group={groupId} disabled={!isOpen}>
+                <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
+                  {title && <Modal.Header title={title} showClose={showClose} />}
+                  {children}
+                </ModalContent>
+              </FocusLock>
             </Backdrop>
           )}
         </Transition>
@@ -118,6 +121,7 @@ function Modal({ children, title, animationDuration, showClose, onClose, open, .
 }
 
 Modal.propTypes = {
+  groupId: PropTypes.string.isRequired,
   open: PropTypes.bool,
   showClose: PropTypes.bool,
   closeOnBackdropClick: PropTypes.bool,

--- a/src/Modal/Modal.mdx
+++ b/src/Modal/Modal.mdx
@@ -20,7 +20,7 @@ Modals are a great way to add dialogs to your site for lightboxes, user notifica
 Toggle a working modal demo by clicking the button below. It will slide up and fade in from the bottom of the page.
 
 <Playground>
-  <ModalExample groupId={1} body="I am an example modal that displays example content to prove that I can actually do some things" maxWidth={300} />
+  <ModalExample body="I am an example modal that displays example content to prove that I can actually do some things" maxWidth={300} />
 </Playground>
 
 ## Handling Long Content
@@ -28,7 +28,7 @@ Toggle a working modal demo by clicking the button below. It will slide up and f
 When modals become too long for the user’s viewport or device, they scroll independent of the page itself.
 
 <Playground>
-  <ModalExample groupdId={2} body={<div>{new Array(50).fill(null).map((_, i) => <p key={i}>I'm really long annoying content.</p>)}</div>} />
+  <ModalExample body={<div>{new Array(50).fill(null).map((_, i) => <p key={i}>I'm really long annoying content.</p>)}</div>} />
 </Playground>
 
 ## Handling Dropdown Triggered Content
@@ -36,5 +36,5 @@ When modals become too long for the user’s viewport or device, they scroll ind
 When modals are triggered by dropdowns with returnFocus set to true, modals still receive focus. 
 
 <Playground>
-  <ModalDropdownExample groupdId={3} body="I'm triggered by a dropdown" />
+  <ModalDropdownExample body="I'm triggered by a dropdown" />
 </Playground>

--- a/src/Modal/Modal.mdx
+++ b/src/Modal/Modal.mdx
@@ -6,6 +6,7 @@ name: Modal
 import { Playground, PropsTable } from 'docz'
 import Modal from './Modal'
 import ModalExample from './Modal.example'
+import ModalDropdownExample from './Modal.dropdownexample'
 
 # Modal
 
@@ -19,7 +20,7 @@ Modals are a great way to add dialogs to your site for lightboxes, user notifica
 Toggle a working modal demo by clicking the button below. It will slide up and fade in from the bottom of the page.
 
 <Playground>
-  <ModalExample body="I am an example modal that displays example content to prove that I can actually do some things" maxWidth={300} />
+  <ModalExample groupId={1} body="I am an example modal that displays example content to prove that I can actually do some things" maxWidth={300} />
 </Playground>
 
 ## Handling Long Content
@@ -27,5 +28,13 @@ Toggle a working modal demo by clicking the button below. It will slide up and f
 When modals become too long for the user’s viewport or device, they scroll independent of the page itself.
 
 <Playground>
-  <ModalExample body={<div>{new Array(50).fill(null).map((_, i) => <p key={i}>I'm really long annoying content.</p>)}</div>} />
+  <ModalExample groupdId={2} body={<div>{new Array(50).fill(null).map((_, i) => <p key={i}>I'm really long annoying content.</p>)}</div>} />
+</Playground>
+
+## Handling Dropdown Triggered Content
+
+When modals are triggered by dropdowns with returnFocus set to true, modals still receive focus. 
+
+<Playground>
+  <ModalDropdownExample groupdId={3} body="I'm triggered by a dropdown" />
 </Playground>


### PR DESCRIPTION
These changes:
- Lock focus in modals (via `react-focus-lock`)
- Adds an example with a dropdown (to illustrate how returnFocus is handled)

![image](https://user-images.githubusercontent.com/16051172/57033527-fdc7af00-6c01-11e9-8ad8-428401ee6e7d.png)

Next steps:
- add VRT with puppeteer, and tie into CI
- consider using [react-focus-on](https://github.com/theKashey/react-focus-on) for modals as recommended by [react-focus-lock](https://github.com/theKashey/react-focus-lock#more)
- close on escape keypress