### PR TITLE
fix(Dropdown): Fix SSR by removing direct reference to Element in prop types

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -195,7 +195,7 @@ Dropdown.propTypes = {
   zIndex: PropTypes.number,
   transitionDuration: PropTypes.number,
   transitionTimingFunction: PropTypes.string,
-  portalNode: PropTypes.instanceOf(Element),
+  portalNode: PropTypes.element,
 };
 
 Dropdown.defaultProps = {


### PR DESCRIPTION
Gatsby breaks when building:
```
11:24:58 AM:   2842 |   transitionDuration: PropTypes.number,
11:24:58 AM:   2843 |   transitionTimingFunction: PropTypes.string,
11:24:58 AM: > 2844 |   portalNode: PropTypes.instanceOf(Element)
11:24:58 AM:        |                        ^
11:24:58 AM:   2845 | };
11:24:58 AM:   2846 | Dropdown.defaultProps = {
11:24:58 AM:   2847 |   placement: 'bottom-start',
11:24:58 AM: 
11:24:58 AM:   WebpackError: ReferenceError: Element is not defined
```