### PR TITLE
feat: Checkbox color updates & Extending theme based styling to variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "molekule",
   "description": "React component library built on top of styled-components and styled-system",
-  "version": "4.0.0",
+  "version": "3.5.7",
   "main": "lib/molekule.js",
   "module": "lib/molekule.es.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "molekule",
   "description": "React component library built on top of styled-components and styled-system",
-  "version": "3.5.7",
+  "version": "4.0.0",
   "main": "lib/molekule.js",
   "module": "lib/molekule.es.js",
   "files": [

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -58,14 +58,14 @@ class Checkbox extends React.Component {
     iconOff: PropTypes.string,
     iconSize: PropTypes.number,
     fontSize: PropTypes.number,
-    color: PropTypes.string,
     horizontal: PropTypes.bool,
     disabled: PropTypes.bool,
     styles: PropTypes.shape(),
+    colorOn: PropTypes.string,
+    colorOff: PropTypes.string,
   };
 
   static defaultProps = {
-    color: 'primary',
     iconOn: 'checkbox-marked',
     iconOff: 'checkbox-blank-outline',
     valueTrue: true,

--- a/src/Form/CheckboxGroup.js
+++ b/src/Form/CheckboxGroup.js
@@ -9,7 +9,6 @@ import { createEasyInput } from './EasyInput';
 class CheckboxGroup extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    color: PropTypes.string,
     horizontal: PropTypes.bool,
     value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     choices: PropTypes.arrayOf(
@@ -20,13 +19,15 @@ class CheckboxGroup extends Component {
       })
     ).isRequired,
     onChange: PropTypes.func,
+    colorOn: PropTypes.string,
+    colorOff: PropTypes.string,
   };
 
   static defaultProps = {
-    defaultValue: [],
-    color: 'primary',
     horizontal: false,
     onChange() {},
+    colorOn: 'primary',
+    colorOff: 'grayMid',
   };
 
   state = {
@@ -60,7 +61,7 @@ class CheckboxGroup extends Component {
   };
 
   render() {
-    const { name, color, choices, error, horizontal } = this.props;
+    const { name, choices, error, horizontal, colorOn, colorOff } = this.props;
     const { selected } = this.state;
 
     return (
@@ -77,7 +78,8 @@ class CheckboxGroup extends Component {
                   id={key}
                   name={key}
                   label={choice.label}
-                  color={color}
+                  colorOn={colorOn}
+                  colorOff={colorOff}
                   horizontal={horizontal}
                   value={selected && selected.includes(value) ? value : null}
                   valueTrue={value}

--- a/src/__snapshots__/utils.spec.js.snap
+++ b/src/__snapshots__/utils.spec.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#utils #getComponentStyle should return top-level component style from theme 1`] = `
+"
+      background-color: tomato;
+    "
+`;
+
+exports[`#utils #getComponentVariant should return primary variant from theme 1`] = `
+Object {
+  "style": "
+          background-color: blue;
+        ",
+}
+`;
+
+exports[`#utils #getComponentVariant should throw error if variant not found 1`] = `[Error: Molekule: "foobar" variant not found in theme...]`;
+
+exports[`#utils #getVariantStyles should return variant style for component from theme 1`] = `
+"
+          background-color: blue;
+        "
+`;
+
+exports[`#utils #themeGet should fallback when theme config not found 1`] = `
+Object {
+  "primary": Object {
+    "style": "background-color: green",
+  },
+}
+`;
+
+exports[`#utils #themeGet should return theme config 1`] = `
+Object {
+  "primary": Object {
+    "style": "
+          background-color: blue;
+        ",
+  },
+}
+`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 export const themeGet = (lookup, fallback) => ({ theme } = {}) => get(theme, lookup, fallback);
 
 export const getComponentVariant = (theme, componentName, variant) => {
-  const config = themeGet(`variants.${componentName}.${variant}`, theme.variants[componentName][variant])({
+  const config = themeGet(`variants.${componentName}.${variant}`)({
     theme,
   });
 
@@ -12,10 +12,12 @@ export const getComponentVariant = (theme, componentName, variant) => {
   return config;
 };
 
-export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
+const getComponentStyle = componentName => themeGet(`components.${componentName}.style`, {});
 
-export const getComponentVariantStyles = (componentName, variant) =>
-  themeGet(`components.${componentName}.variants.${variant}.style`);
+const getComponentVariantStyles = (componentName, variant) =>
+  themeGet(`components.${componentName}.variants.${variant}.style`, {});
+
+const getVariantStyles = (componentName, variant) => themeGet(`variants.${componentName}.${variant}.style`, {});
 
 const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
   `${className || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
@@ -36,10 +38,11 @@ export const createComponent = ({ name, tag = 'div', as, style, props: getBasePr
       className: getComponentClassName(finalProps, kebabCase(name)),
     };
   })`
-    ${style}
-    ${getComponentStyle(name)}
-    ${p => getComponentVariantStyles(name, p.variant)}
-    ${({ styles = {} }) => styles[name] || {}}
+  ${style}
+  ${getComponentStyle(name)}
+  ${p => getVariantStyles(name, p.variant)}
+  ${p => getComponentVariantStyles(name, p.variant)}
+  ${({ styles = {} }) => styles[name] || {}}
 `;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,14 +4,18 @@ import styled from 'styled-components';
 export const themeGet = (lookup, fallback) => ({ theme } = {}) => get(theme, lookup, fallback);
 
 export const getComponentVariant = (theme, componentName, variant) => {
-  const config = themeGet(`components.${componentName}.variants.${variant}`, theme.variants[componentName][variant])({
+  const config = themeGet(`variants.${componentName}.${variant}`, theme.variants[componentName][variant])({
     theme,
   });
+
   if (!config) throw new Error(`Molekule: "${variant}" variant not found in theme...`);
   return config;
 };
 
 export const getComponentStyle = componentName => themeGet(`components.${componentName}.style`);
+
+export const getComponentVariantStyles = (componentName, variant) =>
+  themeGet(`components.${componentName}.variants.${variant}.style`);
 
 const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
   `${className || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();
@@ -34,8 +38,9 @@ export const createComponent = ({ name, tag = 'div', as, style, props: getBasePr
   })`
     ${style}
     ${getComponentStyle(name)}
+    ${p => getComponentVariantStyles(name, p.variant)}
     ${({ styles = {} }) => styles[name] || {}}
-  `;
+`;
 };
 
 // eslint-disable-next-line

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export const getComponentVariant = (theme, componentName, variant) => {
   return config;
 };
 
-const getComponentStyle = componentName => themeGet(`components.${componentName}.style`, {});
+const getComponentStyle = componentName => themeGet(`styles.${componentName}`, {});
 
 const getVariantStyles = (componentName, variant) => themeGet(`variants.${componentName}.${variant}.style`, {});
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,9 +12,9 @@ export const getComponentVariant = (theme, componentName, variant) => {
   return config;
 };
 
-const getComponentStyle = componentName => themeGet(`styles.${componentName}`, {});
+export const getComponentStyle = componentName => themeGet(`styles.${componentName}`, {});
 
-const getVariantStyles = (componentName, variant) => themeGet(`variants.${componentName}.${variant}.style`, {});
+export const getVariantStyles = (componentName, variant) => themeGet(`variants.${componentName}.${variant}.style`, {});
 
 const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
   `${className || ''} ${classPrefix}-${name} ${variant ? `${classPrefix}-${name}-${variant}` : ''}`.trim();

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,9 +14,6 @@ export const getComponentVariant = (theme, componentName, variant) => {
 
 const getComponentStyle = componentName => themeGet(`components.${componentName}.style`, {});
 
-const getComponentVariantStyles = (componentName, variant) =>
-  themeGet(`components.${componentName}.variants.${variant}.style`, {});
-
 const getVariantStyles = (componentName, variant) => themeGet(`variants.${componentName}.${variant}.style`, {});
 
 const getComponentClassName = ({ className, theme: { classPrefix }, variant }, name) =>
@@ -41,7 +38,6 @@ export const createComponent = ({ name, tag = 'div', as, style, props: getBasePr
   ${style}
   ${getComponentStyle(name)}
   ${p => getVariantStyles(name, p.variant)}
-  ${p => getComponentVariantStyles(name, p.variant)}
   ${({ styles = {} }) => styles[name] || {}}
 `;
 };

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,58 @@
+import { getComponentStyle, getVariantStyles, getComponentVariant, themeGet } from './utils';
+
+const MOCK_THEME = {
+  variants: {
+    Element: {
+      primary: {
+        style: `
+          background-color: blue;
+        `,
+      },
+    },
+  },
+  styles: {
+    Element: `
+      background-color: tomato;
+    `,
+  },
+};
+
+describe('#utils', () => {
+  describe('#themeGet', () => {
+    it('should return theme config', () => {
+      expect(themeGet('variants.Element')({ theme: MOCK_THEME })).toMatchSnapshot();
+    });
+
+    it('should fallback when theme config not found', () => {
+      expect(
+        themeGet('variants.foobar', { primary: { style: `background-color: green` } })({ theme: MOCK_THEME })
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('#getComponentVariant', () => {
+    it('should return primary variant from theme', () => {
+      expect(getComponentVariant(MOCK_THEME, 'Element', 'primary')).toMatchSnapshot();
+    });
+
+    it('should throw error if variant not found', () => {
+      try {
+        getComponentVariant(MOCK_THEME, 'Element', 'foobar');
+      } catch (error) {
+        expect(error).toMatchSnapshot();
+      }
+    });
+  });
+
+  describe('#getComponentStyle', () => {
+    it('should return top-level component style from theme', () => {
+      expect(getComponentStyle('Element')({ theme: MOCK_THEME })).toMatchSnapshot();
+    });
+  });
+
+  describe('#getVariantStyles', () => {
+    it('should return variant style for component from theme', () => {
+      expect(getVariantStyles('Element', 'primary')({ theme: MOCK_THEME })).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add the ability to pass `colorOn ` & `colorOff` when using a `CheckboxGroup`
- Add the ability to extend theme based styling into variants as well
- Changes are based on issues encountered with PRD updates

## Theme styling updates

**Problem**
When extending the styles for a particular component at the theme level, I can't dig deeper into a per variant basis. This causes problems when trying to change the `hover` state for a secondary button only for example.

**Solution**
Allow for the ability to pass styles into the variant level as well. 

For example if I want to target a secondary button only I can pass this following in `theme.js`. The `style` key accepts a template string or a style object.

```
{  
  Button: {
      variants: {
        secondary: {
          style: `
            &:hover {
              background-color: tomato;
            }
          `,
        },
      },
    },
}
```