### PR TITLE
fix(Formbot): Validate fields when setting state directly

### DIFF
--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -73,12 +73,15 @@ export default class Formbot extends React.Component {
   }
 
   setValues(values = {}) {
-    this.setState({
-      values: {
-        ...this.state.values,
-        ...values,
+    this.setState(
+      {
+        values: {
+          ...this.state.values,
+          ...values,
+        },
       },
-    });
+      this.validateAllFields
+    );
   }
 
   updateField(field, updates = {}) {
@@ -173,7 +176,9 @@ export default class Formbot extends React.Component {
 
   validateAllFields() {
     return Promise.all(
-      this.validatableFields.map(field => this.updateField(field, {}).then(() => this.validateField(field)))
+      this.validatableFields.map(field =>
+        this.updateField(field, { validated: false }).then(() => this.validateField(field))
+      )
     );
   }
 


### PR DESCRIPTION
## Summary
> Bug scenario:
1. Blur out of a required field, e.g zip
2. Use `Formbot#setValues` to update the field programmatically
3. We expect the validation message to disappear but it doesn't 
![formbot](https://user-images.githubusercontent.com/6404663/61919496-be5fe480-af0a-11e9-896c-4665535f2c76.gif)

The issue was twofold: 
1. We weren't running validations as a callback after values were set with `#setValues`
2. `#updateField` in `#validateAllFields` wasn't being called with`{ validated: false }`, which caused `#validateField` to bail when it reached this condition: 

```js
const fieldState = this.state.fields[field] || {};
// field was already validated the first time around and
// thus bailed out of subsequent validations
if (fieldState.validated) { validations
  resolve();
  return;
}
```

