### PR TITLE
fix(Input): Display floating input label if value is not undefined

### DIFF
--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -241,7 +241,7 @@ class Input extends Component {
       ...rest
     } = this.props;
 
-    const isFloating = (floating && (value && value.length > 0) || (this.state.value || this.state.value === 0));
+    const isFloating = floating && ((value && value.length > 0) || (this.state.value || this.state.value === 0));
 
     const inputProps = {
       ...rest,

--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -241,7 +241,7 @@ class Input extends Component {
       ...rest
     } = this.props;
 
-    const isFloating = (floating && value && value.length > 0) || (floating && this.state.value !== undefined);
+    const isFloating = (floating && (value && value.length > 0) || (this.state.value || this.state.value === 0));
 
     const inputProps = {
       ...rest,

--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -241,7 +241,7 @@ class Input extends Component {
       ...rest
     } = this.props;
 
-    const isFloating = (floating && value && value.length > 0) || (floating && this.state.value);
+    const isFloating = (floating && value && value.length > 0) || (floating && this.state.value !== undefined);
 
     const inputProps = {
       ...rest,

--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -241,7 +241,7 @@ class Input extends Component {
       ...rest
     } = this.props;
 
-    const isFloating = floating && ((value && value.length > 0) || (this.state.value || this.state.value === 0));
+    const isFloating = floating && value != undefined && `${value}`.trim();
 
     const inputProps = {
       ...rest,

--- a/src/Form/Label.js
+++ b/src/Form/Label.js
@@ -9,7 +9,6 @@ const Label = createComponent({
     transition: 250ms;
     font-weight: 500;
     margin: 0 0 4px 4px;
-    z-index: 10;
     font-size: ${p => p.theme.fontSizes[p.size]}px;
 
     ${isFloatable &&


### PR DESCRIPTION
This change ensures that floating labels appear for zero values.

## Summary
### Bug:
1. Blur out of an input with a floating label, and a value of 0 (can be tested via `value={0}`).
3. We expect the label to remain, but it doesn't: 
![Screen Shot 2019-07-31 at 1 45 31 PM](https://user-images.githubusercontent.com/16051172/62246920-b1337180-b3b2-11e9-9625-3c423a75b6dc.png)

### Cause:
1. Zero values were not being accounted for in checking whether to display floating labels. Checking for zero values allows the label to be displayed:
![Screen Shot 2019-07-31 at 1 58 38 PM](https://user-images.githubusercontent.com/16051172/62247751-55112300-b39b-11e9-93b7-a3c3b1fc988e.png)


