### PR TITLE
chore(Modal): Use correct file name casing for linux build

### DIFF
--- a/src/Modal/Modal.mdx
+++ b/src/Modal/Modal.mdx
@@ -6,7 +6,7 @@ name: Modal
 import { Playground, PropsTable } from 'docz'
 import Modal from './Modal'
 import ModalExample from './Modal.example'
-import ModalDropdownExample from './Modal.dropdownexample'
+import ModalDropdownExample from './Modal.dropdownExample'
 
 # Modal
 


### PR DESCRIPTION
Netlify build failing to do incorrectly capitalized file name. Non issue on Macs. First time using Github editor for PR ... not bad