### PR TITLE
chore(docs): Remove base path for distro build

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,5 +1,5 @@
 export default {
-  base: process.env.NODE_ENV === 'production' ? '/molekule' : '',
+  base: '',
   title: 'Molekule',
   dest: './dist',
   description: 'React UI Framework based on styled-components and styled-system',


### PR DESCRIPTION
Deploy preview now working as intended.

The index.html script paths were prefixed by the base set in the config, e.g. `/molekule/static/js/bitcoinminer.js`. Docs on Netlify will be hosted at the root so base is no longer needed. I'm doing this from an iPad on a train, forgive me.