### PR TITLE
Async Formbot Validations

### DIFF
--- a/src/Form/EasyInput.js
+++ b/src/Form/EasyInput.js
@@ -8,7 +8,7 @@ import { Context } from './Formbot';
  */
 const PureInput = React.memo(({ Component, ...props }) => <Component {...props} />);
 
-function EasyInput({ name, Component, ...props }) {
+function EasyInput({ name, Component, renderError = true, ...props }) {
   const state = useContext(Context);
 
   if (!state) {
@@ -25,7 +25,7 @@ function EasyInput({ name, Component, ...props }) {
     <PureInput
       name={name}
       value={value !== undefined ? value : defaultValue}
-      error={state.errors[name]}
+      error={renderError ? state.errors[name] : undefined}
       onChange={state.onChange}
       onBlur={state.onBlur}
       onFocus={state.onFocus}
@@ -36,6 +36,6 @@ function EasyInput({ name, Component, ...props }) {
 }
 
 export const createEasyInput = Component =>
-  forwardRef((props, ref) => <EasyInput Component={Component} forwardedRef={ref} {...props} />);
+  forwardRef((props, ref) => <EasyInput Component={Component} forwardedRef={ref} {...props} />); // eslint-disable-line
 
 export default EasyInput;

--- a/src/Form/EasyInput.js
+++ b/src/Form/EasyInput.js
@@ -8,7 +8,7 @@ import { Context } from './Formbot';
  */
 const PureInput = React.memo(({ Component, ...props }) => <Component {...props} />);
 
-function EasyInput({ name, Component, renderError = true, ...props }) {
+function EasyInput({ name, Component, shouldRenderError = true, ...props }) {
   const state = useContext(Context);
 
   if (!state) {
@@ -25,7 +25,7 @@ function EasyInput({ name, Component, renderError = true, ...props }) {
     <PureInput
       name={name}
       value={value !== undefined ? value : defaultValue}
-      error={renderError ? state.errors[name] : undefined}
+      error={shouldRenderError ? state.errors[name] : undefined}
       onChange={state.onChange}
       onBlur={state.onBlur}
       onFocus={state.onFocus}

--- a/src/Form/FormError.js
+++ b/src/Form/FormError.js
@@ -1,7 +1,11 @@
+/* eslint-disable no-nested-ternary */
+import React, { useContext } from 'react';
 import { css } from 'styled-components';
+import { get } from 'lodash';
 import { createComponent } from '../utils';
+import { Context as FormbotContext } from './Formbot';
 
-const FormError = createComponent({
+const FormErrorContainer = createComponent({
   name: 'FormError',
   tag: 'span',
   style: css`
@@ -11,5 +15,22 @@ const FormError = createComponent({
     font-size: 10px;
   `,
 });
+
+const FormError = ({ name, children }) => {
+  const context = useContext(FormbotContext);
+  const hasNameOnly = !!name && typeof children !== 'function';
+  const hasRenderProp = !!name && typeof children === 'function';
+  const error = get(context.errors, name);
+
+  if (hasNameOnly && error) return <FormErrorContainer>{error}</FormErrorContainer>;
+
+  return hasRenderProp ? (
+    error ? (
+      <FormErrorContainer>{children(error, context)}</FormErrorContainer>
+    ) : null
+  ) : (
+    <FormErrorContainer>{children}</FormErrorContainer>
+  );
+};
 
 export default FormError;

--- a/src/Form/Formbot.example.js
+++ b/src/Form/Formbot.example.js
@@ -10,6 +10,7 @@ import RadioGroup from './RadioGroup';
 import Switch from './Switch';
 import PhoneInput from './PhoneInput';
 import DateInput from './DateInput';
+import FormError from './FormError';
 
 const selectValues = [{ id: 1, value: 'male', label: 'Male' }, { id: 1, value: 'female', label: 'Female' }];
 
@@ -84,7 +85,12 @@ export default class FormbotExample extends React.Component {
         <Form>
           <Fieldset legend="A Group of Inputs">
             <Input name="name" placeholder="Name (should autofocus)" label="Name" ref={this.nameRef} />
-            <Input name="email" placeholder="Email" label="Email" />
+
+            <Input name="email" placeholder="Email" label="Email" renderError={false} />
+            <FormError name="email">
+              {error => <span style={{ color: 'navy' }}>Hi, I am a custom error: {error}</span>}
+            </FormError>
+
             <PhoneInput name="phone" placeholder="Phone Number" label="Phone" />
             <DateInput name="dob" placeholder="MM/DD/YYYY" label="Date of Birth" />
             <Select name="gender" placeholder="Select a Gender" label="Gender" options={selectValues} />

--- a/src/Form/Formbot.example.js
+++ b/src/Form/Formbot.example.js
@@ -86,7 +86,7 @@ export default class FormbotExample extends React.Component {
           <Fieldset legend="A Group of Inputs">
             <Input name="name" placeholder="Name (should autofocus)" label="Name" ref={this.nameRef} />
 
-            <Input name="email" placeholder="Email" label="Email" renderError={false} />
+            <Input name="email" placeholder="Email" label="Email" shouldRenderError={false} />
             <FormError name="email">
               {error => <span style={{ color: 'navy' }}>Hi, I am a custom error: {error}</span>}
             </FormError>

--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -138,6 +138,7 @@ export default class Formbot extends React.Component {
       const hasSchema = !!validationSchema;
       const isAsyncValidation = hasSchema && validationSchema.async;
       const validation = (validationSchema || validations || {})[field];
+      const validationOpts = { context: this.getContext() };
 
       if (!validation) {
         resolve();
@@ -150,14 +151,14 @@ export default class Formbot extends React.Component {
       try {
         if (hasSchema) {
           if (typeof validation.validate === 'function' && isAsyncValidation) {
-            validation.validate(fieldValue, { context: this.getContext() }).catch(e => {
+            validation.validate(fieldValue, validationOpts).catch(e => {
               this.setErrors({ [field]: e.message }, resolve);
             });
 
             return;
           }
 
-          validation.validateSync(fieldValue);
+          validation.validateSync(fieldValue, validationOpts);
         } else if (typeof validation === 'function') {
           validation(fieldValue);
         } else {

--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { omit } from 'lodash';
 
 export const Context = React.createContext(null);
 
@@ -53,7 +52,7 @@ export default class Formbot extends React.Component {
   get validatableFields() {
     const { validationSchema, validations } = this.props;
 
-    return Object.keys(omit(validationSchema, ['async']) || validations || {});
+    return Object.keys(validationSchema || validations || {});
   }
 
   get validatable() {
@@ -136,7 +135,7 @@ export default class Formbot extends React.Component {
       const { validationSchema, validations } = this.props;
 
       const hasSchema = !!validationSchema;
-      const isAsyncValidation = hasSchema && validationSchema.async;
+
       const validation = (validationSchema || validations || {})[field];
       const validationOpts = { context: this.getContext() };
 
@@ -149,16 +148,12 @@ export default class Formbot extends React.Component {
       let errorMsg;
 
       try {
-        if (hasSchema) {
-          if (typeof validation.validate === 'function' && isAsyncValidation) {
-            validation.validate(fieldValue, validationOpts).catch(e => {
-              this.setErrors({ [field]: e.message }, resolve);
-            });
+        if (hasSchema && typeof validation.validate === 'function') {
+          validation.validate(fieldValue, validationOpts).catch(e => {
+            this.setErrors({ [field]: e.message }, resolve);
+          });
 
-            return;
-          }
-
-          validation.validateSync(fieldValue, validationOpts);
+          return;
         } else if (typeof validation === 'function') {
           validation(fieldValue);
         } else {

--- a/src/Form/Formbot.mdx
+++ b/src/Form/Formbot.mdx
@@ -50,7 +50,6 @@ Quickly build a form using a Formbot and pre-configured form components. Formbot
 ```jsx
 <Formbot
   validationSchema={{
-    async: true, // required for async validation
     state: yup.string().required(),
     zip: yup
       .string()
@@ -59,7 +58,7 @@ Quickly build a form using a Formbot and pre-configured form components. Formbot
       .test('valid', 'Zip does not match selected state!', async function(value) {
         const {
           options: {
-            context: { values },
+            context: { values }, // Formbot context
           },
         } = this;
 

--- a/src/Form/Formbot.mdx
+++ b/src/Form/Formbot.mdx
@@ -3,15 +3,15 @@ menu: Forms
 name: Formbot
 ---
 
-import { Playground, PropsTable } from 'docz'
+import { Playground, PropsTable } from 'docz';
 import * as yup from 'yup';
-import FormExample from './Formbot.example'
-import Formbot from './Formbot'
+import FormExample from './Formbot.example';
+import Formbot from './Formbot';
 import Form from './Form';
 import Field from './Field';
-import Button from '../Button'
-import FormGroup from './FormGroup'
-import Input from './Input'
+import Button from '../Button';
+import FormGroup from './FormGroup';
+import Input from './Input';
 
 # Formbot
 
@@ -24,6 +24,7 @@ Quickly build a form using a Formbot and pre-configured form components. Formbot
 ## Examples
 
 ### Formbot
+
 <Playground>
   <Formbot
     validationSchema={{
@@ -40,11 +41,46 @@ Quickly build a form using a Formbot and pre-configured form components. Formbot
         </Button>
       </Field>
     </Form>
+
   </Formbot>
 </Playground>
 
+### Async Validation
+
+```jsx
+<Formbot
+  validationSchema={{
+    async: true, // required for async validation
+    state: yup.string().required(),
+    zip: yup
+      .string()
+      .min(5)
+      .required()
+      .test('valid', 'Zip does not match selected state!', async function(value) {
+        const {
+          options: {
+            context: { values },
+          },
+        } = this;
+
+        const stateFromZip = await getStateFromZip(value);
+
+        return stateFromZip === values.state;
+      }),
+  }}>
+  <Form>
+    <Input name="state" label="State" />
+    <Input name="zip" label="Zip" />
+
+    <Field>
+      <Button type="submit">Update</Button>
+    </Field>
+  </Form>
+</Formbot>
+```
+
 ### Entire Form
+
 <Playground>
   <FormExample />
 </Playground>
-


### PR DESCRIPTION
## Why? 
Our validation schema library `yup` allows for sync as well as async validations and we've not been able to utilize this feature due to the constraint of `Formbot` validating forms synchronously. Most recently, Scott on the `web-app` and myself on the `mobile-app` have run into an issue where we needed to hit an API endpoint as part of validating a patient's address (zip + state matching) but making this work required some ninjitsu (utilizing local state, effects to run the validations, etc). With this proposal, all of that goes away and we can define smarter validation schemas that support async validations. 

## Architecture 
There are no breaking changes in the PR so we can adopt as needed, but we now allow the ability to pass a function to `validationSchema`. The function will be called with one argument, the Formbot context and expects a return object with a `yup` schema definition. 

```jsx
const createSchema = ({ values: { state } }) => ({
  state: yup
    .string()
    .required()
    .test('valid-state', 'Not available in your state!', async value => {
      const isValidState = await validateServiceAvailability({ state: value });
      return isValidState;
    }),
  zip: yup
    .string()
    .min(5)
    .required()
    .test('valid-zip', 'Zip does not match state', async zip => {
      const stateFromZip = await getStateFromZip(zip);
      return stateFromZip === state;
    }),
});

<Formbot validationSchema={createSchema}>
  <Input name="state" />
  <Input name="zip" />
</Formbot>;
```

## What Else?
I've also refactored `FormError` to be a be a much smarter component. Sometimes we want to render an error that is outside of an input (something that spans an entire row, for example, instead of just showing up underneath a field). `FormError` is now connected to the `Formbot` context and can render the appropriate error given a `name` prop that corresponds to the error key. 

```jsx
<Formbot validationSchema={createSchema}>
  <Input name="state" renderError={false} />
  <FormError name="state" /> // default error
  <FormError name="state">{error => <span>My custom error {error}</span>}</FormError>;
</Formbot>;
```