### PR TITLE
fix(validations): Fix handling of async validations as well as order of onChange notification

### DIFF
--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -210,9 +210,7 @@ export default class Formbot extends React.Component {
       () => {
         this.updateField(field, { validated: false })
           .then(() => this.validateField(field))
-          .then(() => {
-            this.props.onChange(field, value, this.state.values);
-          })
+          .then(() => this.props.onChange(field, value, this.state.values))
       }
     );
   };

--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -147,14 +147,22 @@ export default class Formbot extends React.Component {
       const fieldValue = this.state.values[field];
       let errorMsg;
 
-      try {
-        if (hasSchema && typeof validation.validate === 'function') {
-          validation.validate(fieldValue, validationOpts).catch(e => {
-            this.setErrors({ [field]: e.message }, resolve);
-          });
+      if (hasSchema && typeof validation.validate === 'function') {
+        validation.validate(fieldValue, validationOpts)
+          .catch(e => {
+            errorMsg = e.message;
+          })
+          .finally(() => {
+            this.updateField(field, { validated: true }).then(() => {
+              this.setErrors({ [field]: errorMsg }, resolve);
+            });
+          })
 
-          return;
-        } else if (typeof validation === 'function') {
+        return;
+      }
+
+      try {
+        if (typeof validation === 'function') {
           validation(fieldValue);
         } else {
           Object.keys(validation).forEach(method => {
@@ -200,10 +208,11 @@ export default class Formbot extends React.Component {
         },
       },
       () => {
-        this.props.onChange(field, value, this.state.values);
-        this.updateField(field, { validated: false }).then(() => {
-          this.validateField(field);
-        });
+        this.updateField(field, { validated: false })
+          .then(() => this.validateField(field))
+          .then(() => {
+            this.props.onChange(field, value, this.state.values);
+          })
       }
     );
   };

--- a/src/Form/Formbot.mdx
+++ b/src/Form/Formbot.mdx
@@ -47,36 +47,29 @@ Quickly build a form using a Formbot and pre-configured form components. Formbot
 
 ### Async Validation
 
-```jsx
-<Formbot
-  validationSchema={{
-    state: yup.string().required(),
-    zip: yup
-      .string()
-      .min(5)
-      .required()
-      .test('valid', 'Zip does not match selected state!', async function(value) {
-        const {
-          options: {
-            context: { values }, // Formbot context
-          },
-        } = this;
-
-        const stateFromZip = await getStateFromZip(value);
-
-        return stateFromZip === values.state;
+<Playground>
+  <Formbot
+    validationSchema={{
+      random: yup.string().test('valid', 'This test was delayed by 2 seconds.', async function(value) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(false);
+          }, 2000);
+        });
       }),
-  }}>
-  <Form>
-    <Input name="state" label="State" />
-    <Input name="zip" label="Zip" />
+    }}>
+    <Form>
+      <Input name="random" label="random" />
 
-    <Field>
-      <Button type="submit">Update</Button>
-    </Field>
-  </Form>
-</Formbot>
-```
+      <Field>
+        <Button type="submit">
+          Sign In
+        </Button>
+      </Field>
+    </Form>
+
+  </Formbot>
+</Playground>
 
 ### Entire Form
 


### PR DESCRIPTION
It was discovered when refactoring the `AddressForm` component that the `onChange` notification in `FormBot` was called before field updating/validation was complete.  This is an issue if in an `onChange` handler for `FormBot` you are expecting to test for form validity (i.e. updating your UI according to the validity of a recent change to form data).  Additionally the `return` from the async validation block was triggering the `finally` handler causing premature promise resolution and triggering the `onChange` handler before validations were complete.