### PR TITLE
fix: Use updater function in setState for Formbot updates

### DIFF
--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -74,17 +74,16 @@ export default class Formbot extends React.Component {
     }));
   }
 
-  setValues(values = {}) {
+  setValues = (values = {}) =>
     this.setState(
-      {
+      state => ({
         values: {
-          ...this.state.values,
+          ...state.values,
           ...values,
         },
-      },
+      }),
       this.validateAllFields
     );
-  }
 
   setErrors = (errors = {}, cb) =>
     this.setState(
@@ -97,24 +96,21 @@ export default class Formbot extends React.Component {
       cb
     );
 
-  updateField(field, updates = {}) {
-    return new Promise(resolve => {
-      const fieldState = this.state.fields[field] || {};
-
+  updateField = (field, updates = {}) =>
+    new Promise(resolve => {
       this.setState(
-        {
+        state => ({
           fields: {
-            ...this.state.fields,
+            ...state.fields,
             [field]: {
-              ...fieldState,
+              ...state.fields[field],
               ...updates,
             },
           },
-        },
+        }),
         resolve
       );
     });
-  }
 
   reset = () => {
     this.setState({
@@ -148,7 +144,8 @@ export default class Formbot extends React.Component {
       let errorMsg;
 
       if (hasSchema && typeof validation.validate === 'function') {
-        validation.validate(fieldValue, validationOpts)
+        validation
+          .validate(fieldValue, validationOpts)
           .catch(e => {
             errorMsg = e.message;
           })
@@ -156,7 +153,7 @@ export default class Formbot extends React.Component {
             this.updateField(field, { validated: true }).then(() => {
               this.setErrors({ [field]: errorMsg }, resolve);
             });
-          })
+          });
 
         return;
       }
@@ -201,16 +198,16 @@ export default class Formbot extends React.Component {
 
   onChange = (field, value) => {
     this.setState(
-      {
+      state => ({
         values: {
-          ...this.state.values,
+          ...state.values,
           [field]: value,
         },
-      },
+      }),
       () => {
         this.updateField(field, { validated: false })
           .then(() => this.validateField(field))
-          .then(() => this.props.onChange(field, value, this.state.values))
+          .then(() => this.props.onChange(field, value, this.state.values));
       }
     );
   };

--- a/src/Form/Formbot.js
+++ b/src/Form/Formbot.js
@@ -75,15 +75,17 @@ export default class Formbot extends React.Component {
   }
 
   setValues = (values = {}) =>
-    this.setState(
-      state => ({
-        values: {
-          ...state.values,
-          ...values,
-        },
-      }),
-      this.validateAllFields
-    );
+    new Promise(resolve => {
+      this.setState(
+        state => ({
+          values: {
+            ...state.values,
+            ...values,
+          },
+        }),
+        () => this.validateAllFields().then(resolve)
+      );
+    });
 
   setErrors = (errors = {}, cb) =>
     this.setState(


### PR DESCRIPTION
## Summary 
Using a function as a state updater seems to fix an issue with stale state data preventing a validation function from running. 