### PR TITLE
fix(FormError): Fix crash in case context is null

### DIFF
--- a/src/Form/FormError.js
+++ b/src/Form/FormError.js
@@ -20,7 +20,7 @@ const FormError = ({ name, children }) => {
   const context = useContext(FormbotContext);
   const hasNameOnly = !!name && typeof children !== 'function';
   const hasRenderProp = !!name && typeof children === 'function';
-  const error = get(context.errors, name);
+  const error = get(context, ['errors', name]);
 
   if (hasNameOnly && error) return <FormErrorContainer>{error}</FormErrorContainer>;
 


### PR DESCRIPTION
## Summary 
`<FormError />` can be used outside Formbot context and thus we need to ensure that we safely look up the error in case the context is `null`. 