### PR TITLE
feat(Colors): Updates colors

### DIFF
--- a/docs/theme.mdx
+++ b/docs/theme.mdx
@@ -10,154 +10,179 @@ Molekule comes with a default theme. You can override any of these configuration
 
 ```js
 {
-  "breakpoints": [
+  breakpoints: [
     480,
     768,
     1024,
     1440
   ],
-  "classPrefix": "re",
-  "colors": {
-    "primaryDark": "#002BA0",
-    "primary": "#2DAAF2",
-    "primaryLight": "#9FB8FC",
-    "grayDark": "#43526D",
-    "grayMid": "#8E97A7",
-    "gray": "#8E97A7",
-    "grayLight": "#DEE0E4",
-    "grayLightest": "#F1F4F6",
-    "redDark": "#B22327",
-    "red": "#FD575D",
-    "redLight": " #FFCECF",
-    "blueDark": "#006DC1",
-    "blue": "#0747A5",
-    "blueLight": "#C8E8FF",
-    "greenDark": "#196C1C",
-    "green": "#00D684",
-    "greenLight": "#B4F7DE",
-    "orangeDark": "#BB520B",
-    "orange": "#FFAA70",
-    "orangeLight": "#FFD8BD",
-    "yellowDark": "#F1BC0B",
-    "yellow": "#FED23D",
-    "yellowLight": "#FFEDB1",
-    "purpleDark": "#8530FD",
-    "purple": "#9D58FE",
-    "purpleLight": "#DFC8FF"
+  classPrefix: 're',
+  colors: {
+      default: '#494D55',
+      black: '#1B202B',
+      white: '#FFFFFF',
+
+      greyLightest: '#F8F8F9',
+      greyLighter: '#F4F4F4',
+      greyLight: '#E8E9EA',
+      grey: '#D1D2D5',
+      greyDark: '#A4A6AA',
+      greyDarker: '#767980',
+      greyDarkest: '#494D55',
+
+      primaryLightest: '#CADCFF',
+      primaryLight: '#4D89FF',
+      primary: '#226EFF',
+      primaryDark: '#0958F3',
+
+      secondaryLightest: '#DDF5ED',
+      secondaryLight: '#42C79B',
+      secondary: '#21B986',
+      secondaryDark: '#00AC74',
+
+      redLightest: '#FFD7D8',
+      redLight: '#FE7B7E',
+      red: '#FD575D',
+      redDark: '#F23338',
+
+      purpleLightest: '#EBDCFC',
+      purpleLight: '#BB8AF6',
+      purple: '#A262F0',
+      purpleDark: '#8B3FE7',
+
+      orangeLightest: '#FFE6D4',
+      orangeLight: '#FFAA70',
+      orange: '#FF954D',
+      orangeDark: '#EE7523',
+
+      yellowLightest: '#FFF6D6',
+      yellowLight: '#FFE075',
+      yellow: '#FED23D',
+      yellowDark: '#F1BC0B',
+
+      blueLightest: '#CADCFF',
+      blueLight: '#4D89FF',
+      blue: '#226EFF',
+      blueDark: '#0958F3',
+
+      greenLightest: '#DDF5ED',
+      greenLight: '#42C79B',
+      green: '#21B986',
+      greenDark: '#00AC74',
   },
-  "fontSizes": {
-    "xs": 8,
-    "sm": 10,
-    "md": 12,
-    "lg": 14,
-    "xl": 16
+  fontSizes: {
+    xs: 8,
+    sm: 10,
+    md: 12,
+    lg: 14,
+    xl: 16
   },
-  "grid": {
-    "containerMaxWidth": 1000,
-    "gutter": 16,
-    "columns": 12,
-    "sizes": {
-      "xs": 480,
-      "sm": 768,
-      "md": 1024,
-      "lg": 1440
+  grid: {
+    containerMaxWidth: 1000,
+    gutter: 16,
+    columns: 12,
+    sizes: {
+      xs: 480,
+      sm: 768,
+      md: 1024,
+      lg: 1440
     }
   },
-  "heights": {
-    "xs": 28,
-    "sm": 32,
-    "md": 36,
-    "lg": 40,
-    "xl": 44
+  heights: {
+    xs: 28,
+    sm: 32,
+    md: 36,
+    lg: 40,
+    xl: 44
   },
-  "radii": [
+  radii: [
     0,
     2,
     4
   ],
-  "radius": 4,
-  "shadow": "0 3px 6px hsla(0,0%,60%,.1), 0 3px 6px hsla(0,0%,60%,.15), 0 -1px 2px hsla(0,0%,60%,.02)",
-  "shadowHover": "0 6px 9px hsla(0,0%,60%,.2), 0 6px 9px hsla(0,0%,60%,.2), 0 -1px 2px hsla(0,0%,60%,.08)",
-  "typography": {
-    "fontSize": 12
+  radius: 8,
+  shadow: '0 3px 6px hsla(0,0%,60%,.1), 0 3px 6px hsla(0,0%,60%,.15), 0 -1px 2px hsla(0,0%,60%,.02)',
+  shadowHover: '0 6px 9px hsla(0,0%,60%,.2), 0 6px 9px hsla(0,0%,60%,.2), 0 -1px 2px hsla(0,0%,60%,.08)',
+  typography: {
+    fontSize: 12
   },
-  "variants": {
-    "Alert": {
-      "primary": {
-        "backgroundColor": "#9FB8FC",
-        "fontColor": "#002BA0"
+  variants: {
+    Alert: {
+      primary: {
+        backgroundColor: '#CADCFF',
+        fontColor: '#0958F3'
       },
-      "success": {
-        "backgroundColor": "#B4F7DE",
-        "fontColor": "#196C1C"
+      success: {
+        backgroundColor: '#DDF5ED',
+        fontColor: '#00AC74'
       },
-      "danger": {
-        "backgroundColor": " #FFCECF",
-        "fontColor": "#B22327"
+      danger: {
+        backgroundColor: ' #FFD7D8',
+        fontColor: '#F23338'
       },
-      "warning": {
-        "backgroundColor": "#FFD8BD",
-        "fontColor": "#BB520B"
+      warning: {
+        backgroundColor: '#FFE6D4',
+        fontColor: '#EE7523'
       },
-      "info": {
-        "backgroundColor": "#C8E8FF",
-        "fontColor": "#006DC1"
+      info: {
+        backgroundColor: '#CADCFF',
+        fontColor: '#0958F3'
       },
-      "gray": {
-        "backgroundColor": "#DEE0E4",
-        "fontColor": "#43526D"
+      grey: {
+        backgroundColor: '#E8E9EA',
+        fontColor: '#767980'
       }
     },
-    "Badge": {
-      "primary": {
-        "backgroundColor": "#9FB8FC",
-        "fontColor": "#002BA0"
+    Badge: {
+      primary: {
+        backgroundColor: '#CADCFF',
+        fontColor: '#0958F3'
       },
-      "success": {
-        "backgroundColor": "#B4F7DE",
-        "fontColor": "#196C1C"
+      success: {
+        backgroundColor: '#DDF5ED',
+        fontColor: '#00AC74'
       },
-      "danger": {
-        "backgroundColor": " #FFCECF",
-        "fontColor": "#B22327"
+      danger: {
+        backgroundColor: ' #FFD7D8',
+        fontColor: '#F23338'
       },
-      "warning": {
-        "backgroundColor": "#FFD8BD",
-        "fontColor": "#BB520B"
+      warning: {
+        backgroundColor: '#FFE6D4',
+        fontColor: '#EE7523'
       },
-      "info": {
-        "backgroundColor": "#C8E8FF",
-        "fontColor": "#006DC1"
+      info: {
+        backgroundColor: '#CADCFF',
+        fontColor: '#0958F3'
       },
-      "gray": {
-        "backgroundColor": "#DEE0E4",
-        "fontColor": "#43526D"
+      grey: {
+        backgroundColor: '#E8E9EA',
+        fontColor: '#767980'
       }
     },
-    "Button": {
-      "primary": {
-        "backgroundColor": "#2DAAF2",
-        "fontColor": "white"
+    Button: {
+      primary: {
+        backgroundColor: '#226EFF',
+        fontColor: '#FFFFFF'
       },
-      "success": {
-        "backgroundColor": "#00D684",
-        "fontColor": "white"
+      success: {
+        backgroundColor: '#21B986',
+        fontColor: '#FFFFFF'
       },
-      "danger": {
-        "backgroundColor": "#FD575D",
-        "fontColor": "white"
+      danger: {
+        backgroundColor: '#FD575D',
+        fontColor: '#FFFFFF'
       },
-      "warning": {
-        "backgroundColor": "#FFAA70",
-        "fontColor": "white"
+      warning: {
+        backgroundColor: '#FF954D',
+        fontColor: '#FFFFFF'
       },
-      "info": {
-        "backgroundColor": "#0747A5",
-        "fontColor": "white"
+      info: {
+        backgroundColor: '#226EFF',
+        fontColor: '#FFFFFF'
       },
-      "gray": {
-        "backgroundColor": "#DEE0E4",
-        "fontColor": "#43526D"
+      grey: {
+        backgroundColor: '#E8E9EA',
+        fontColor: '#494D55'
       }
     }
   }

--- a/src/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/Badge/__snapshots__/Badge.spec.js.snap
@@ -8,8 +8,8 @@ exports[`Badge 1`] = `
   font-family: inherit;
   font-weight: bold;
   border-radius: 12px;
-  background: #C8E8FF;
-  color: #006DC1;
+  background: #CADCFF;
+  color: #0958F3;
 }
 
 <span

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -30,7 +30,7 @@ Card.Header = createComponent({
   as: Box,
   style: ({ theme }) => css`
     padding: 1rem;
-    border-bottom: 1px solid ${theme.colors.grayLight};
+    border-bottom: 1px solid ${theme.colors.greyLight};
   `,
 });
 
@@ -47,7 +47,7 @@ Card.Footer = createComponent({
   as: Box,
   style: ({ theme }) => css`
     padding: 1rem;
-    border-top: 1px solid ${theme.colors.grayLight};
+    border-top: 1px solid ${theme.colors.greyLight};
   `,
 });
 

--- a/src/Card/__snapshots__/Card.spec.js.snap
+++ b/src/Card/__snapshots__/Card.spec.js.snap
@@ -11,7 +11,7 @@ exports[`Card 1`] = `
 
 .c1 {
   padding: 1rem;
-  border-bottom: 1px solid #DEE0E4;
+  border-bottom: 1px solid #E8E9EA;
 }
 
 .c2 {
@@ -20,7 +20,7 @@ exports[`Card 1`] = `
 
 .c3 {
   padding: 1rem;
-  border-top: 1px solid #DEE0E4;
+  border-top: 1px solid #E8E9EA;
 }
 
 <div

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -230,7 +230,7 @@ const DropdownMenu = createComponent({
     z-index: ${zIndex};
     background: white;
     border-radius: ${theme.radius}px;
-    border: 1px solid #e4edf5;
+    border: 1px solid ${theme.colors.greyLighter};
     outline: none;
     box-shadow: 0 0 3px 0 rgba(178, 194, 212, 0.3);
     width: ${typeof width === 'string' ? width : `${width}px`};
@@ -257,7 +257,7 @@ const DropdownHeaderInner = createComponent({
   name: 'DropdownHeaderInner',
   style: css`
     padding: 0 0 0.25rem;
-    border-bottom: 2px solid ${p => p.theme.colors.grayLight};
+    border-bottom: 2px solid ${p => p.theme.colors.greyLight};
   `,
 });
 
@@ -331,7 +331,7 @@ const StyledDropdownItem = createComponent({
     &:hover,
     &:focus {
       color: inherit;
-      background: ${theme.colors.grayLightest};
+      background: ${theme.colors.greyLightest};
     }
   `,
 });
@@ -356,7 +356,7 @@ Dropdown.Footer = createComponent({
     as: 'footer',
   }),
   style: ({ theme }) => css`
-    background: ${theme.colors.grayLightest};
+    background: ${theme.colors.greyLightest};
     padding: 0.75rem 1rem;
     border-radius: 0 0 ${themeGet('radius')}px ${themeGet('radius')}px;
   `,

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -25,25 +25,25 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
   border-radius: 4px;
   pointer-events: auto;
   opacity: 1;
-  color: white;
+  color: #FFFFFF;
   height: 36px;
   padding: 0 18px;
   font-size: 12px;
   width: auto;
-  background: #2DAAF2;
-  border: 1px solid #2DAAF2;
+  background: #226EFF;
+  border: 1px solid #226EFF;
   -webkit-transition: 175ms;
   transition: 175ms;
 }
 
 .c1:hover {
-  background: #45b4f3;
-  border-color: #45b4f3;
+  background: #3c7fff;
+  border-color: #3c7fff;
 }
 
 .c1:active {
-  background: #51b9f4;
-  border-color: #51b9f4;
+  background: #4887ff;
+  border-color: #4887ff;
 }
 
 <div
@@ -89,25 +89,25 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
   border-radius: 4px;
   pointer-events: auto;
   opacity: 1;
-  color: white;
+  color: #FFFFFF;
   height: 36px;
   padding: 0 18px;
   font-size: 12px;
   width: auto;
-  background: #2DAAF2;
-  border: 1px solid #2DAAF2;
+  background: #226EFF;
+  border: 1px solid #226EFF;
   -webkit-transition: 175ms;
   transition: 175ms;
 }
 
 .c1:hover {
-  background: #45b4f3;
-  border-color: #45b4f3;
+  background: #3c7fff;
+  border-color: #3c7fff;
 }
 
 .c1:active {
-  background: #51b9f4;
-  border-color: #51b9f4;
+  background: #4887ff;
+  border-color: #4887ff;
 }
 
 <div
@@ -139,7 +139,7 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
   z-index: 10;
   background: white;
   border-radius: 4px;
-  border: 1px solid #e4edf5;
+  border: 1px solid #F4F4F4;
   outline: none;
   box-shadow: 0 0 3px 0 rgba(178,194,212,0.3);
   width: auto;
@@ -160,7 +160,7 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
 
 .c2 {
   padding: 0 0 0.25rem;
-  border-bottom: 2px solid #DEE0E4;
+  border-bottom: 2px solid #E8E9EA;
 }
 
 .c3 {
@@ -200,11 +200,11 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
 .c4:hover,
 .c4:focus {
   color: inherit;
-  background: #F1F4F6;
+  background: #F8F8F9;
 }
 
 .c5 {
-  background: #F1F4F6;
+  background: #F8F8F9;
   padding: 0.75rem 1rem;
   border-radius: 0 0 4px 4px;
 }

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -71,7 +71,7 @@ class Checkbox extends React.Component {
     valueTrue: true,
     valueFalse: false,
     colorOn: 'primary',
-    colorOff: 'grayMid',
+    colorOff: 'greyDark',
     iconSize: 18,
     horizontal: false,
     onChange() {},

--- a/src/Form/CheckboxGroup.js
+++ b/src/Form/CheckboxGroup.js
@@ -27,7 +27,7 @@ class CheckboxGroup extends Component {
     horizontal: false,
     onChange() {},
     colorOn: 'primary',
-    colorOff: 'grayMid',
+    colorOff: 'greyDark',
   };
 
   state = {

--- a/src/Form/Input.js
+++ b/src/Form/Input.js
@@ -18,7 +18,7 @@ const StyledInput = createComponent({
   name: 'Input',
   tag: 'input',
   style: ({ isFloating, size, theme, borderRadius = theme.radius }) => css`
-    border: 1px solid ${theme.colors.grayLight};
+    border: 1px solid ${theme.colors.greyLight};
     height: ${theme.heights[size]}px;
     display: block;
     outline: none;
@@ -33,11 +33,11 @@ const StyledInput = createComponent({
     &:hover,
     &:focus,
     &:active {
-      border-color: ${theme.colors.grayMid};
+      border-color: ${theme.colors.greyDark};
     }
 
     ::placeholder {
-      color: ${theme.colors.grayMid};
+      color: ${theme.colors.greyDark};
     }
 
     &[disabled] {

--- a/src/Form/Select.js
+++ b/src/Form/Select.js
@@ -14,7 +14,7 @@ const SelectContainer = createComponent({
   as: Flex,
   style: ({ size, theme, value, borderRadius = theme.radius }) => css`
     background: white;
-    border: 1px solid ${theme.colors.grayLight};
+    border: 1px solid ${theme.colors.greyLight};
     height: ${theme.heights[size]}px;
     outline: none;
     width: 100%;
@@ -28,9 +28,9 @@ const SelectContainer = createComponent({
 
     ${!value &&
       css`
-        color: ${p => p.theme.colors.grayMid};
+        color: ${p => p.theme.colors.greyDark};
         select {
-          color: ${p => p.theme.colors.grayMid};
+          color: ${p => p.theme.colors.greyDark};
         }
       `};
   `,

--- a/src/Form/Switch.js
+++ b/src/Form/Switch.js
@@ -31,7 +31,7 @@ const SwitchThumb = styled.span`
     right: 0;
     bottom: 0;
     transition: 0.3s;
-    background-color: ${on ? backgroundColor : theme.colors.grayMid};
+    background-color: ${on ? backgroundColor : theme.colors.greyDark};
 
     &:before {
       border-radius: 100%;

--- a/src/Form/__snapshots__/DateInput.spec.js.snap
+++ b/src/Form/__snapshots__/DateInput.spec.js.snap
@@ -17,7 +17,7 @@ exports[`<DateInput /> snapshot 1`] = `
 }
 
 .c3 {
-  border: 1px solid #DEE0E4;
+  border: 1px solid #E8E9EA;
   height: 36px;
   display: block;
   outline: none;
@@ -34,23 +34,23 @@ exports[`<DateInput /> snapshot 1`] = `
 .c3:hover,
 .c3:focus,
 .c3:active {
-  border-color: #8E97A7;
+  border-color: #A4A6AA;
 }
 
 .c3::-webkit-input-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3::-moz-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3:-ms-input-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3::placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3[disabled] {

--- a/src/Form/__snapshots__/PhoneInput.spec.js.snap
+++ b/src/Form/__snapshots__/PhoneInput.spec.js.snap
@@ -17,7 +17,7 @@ exports[`<PhoneInput /> snapshot 1`] = `
 }
 
 .c3 {
-  border: 1px solid #DEE0E4;
+  border: 1px solid #E8E9EA;
   height: 36px;
   display: block;
   outline: none;
@@ -34,23 +34,23 @@ exports[`<PhoneInput /> snapshot 1`] = `
 .c3:hover,
 .c3:focus,
 .c3:active {
-  border-color: #8E97A7;
+  border-color: #A4A6AA;
 }
 
 .c3::-webkit-input-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3::-moz-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3:-ms-input-placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3::placeholder {
-  color: #8E97A7;
+  color: #A4A6AA;
 }
 
 .c3[disabled] {

--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -53,7 +53,7 @@ export default class ModalDropdownDemo extends React.Component {
 
           <Modal.Footer>
             <Button.Group justifyContent="flex-end">
-              <Button variant="gray" onClick={this.onCancel}>
+              <Button variant="grey" onClick={this.onCancel}>
                 Cancel
               </Button>
             </Button.Group>

--- a/src/Modal/Modal.example.js
+++ b/src/Modal/Modal.example.js
@@ -52,7 +52,7 @@ export default class ModalDemo extends React.Component {
 
               <Modal.Footer>
                 <Button.Group justifyContent="flex-end">
-                  <Button variant="gray" onClick={this.toggleModalTwo}>
+                  <Button variant="grey" onClick={this.toggleModalTwo}>
                     Cancel
                   </Button>
                   <Button variant="success" onClick={this.toggleModalTwo}>
@@ -65,7 +65,7 @@ export default class ModalDemo extends React.Component {
 
           <Modal.Footer>
             <Button.Group justifyContent="flex-end">
-              <Button variant="gray" onClick={this.onCancel}>
+              <Button variant="grey" onClick={this.onCancel}>
                 Cancel
               </Button>
               <Button variant="success" onClick={this.toggleModalTwo}>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -168,7 +168,7 @@ const ModalHeader = createComponent({
 const ModalHeaderInner = createComponent({
   name: 'ModalHeaderInner',
   style: ({ theme }) => css`
-    border-bottom: 2px solid ${theme.colors.grayLight};
+    border-bottom: 2px solid ${theme.colors.greyLight};
     padding-bottom: 0.25rem;
   `,
 });
@@ -185,7 +185,7 @@ Modal.Header = ({ title, children, showClose = true }) => {
 
           {showClose && (
             <Box ml="auto">
-              <Icon name="close" color="grayMid" style={{ cursor: 'pointer' }} onClick={handleClose} />
+              <Icon name="close" color="greyDark" style={{ cursor: 'pointer' }} onClick={handleClose} />
             </Box>
           )}
         </Flex>
@@ -205,7 +205,7 @@ Modal.Footer = createComponent({
   name: 'ModalFooter',
   style: ({ theme }) => css`
     padding: 1rem 1.25rem;
-    background: ${theme.colors.grayLightest};
+    background: ${theme.colors.greyLightest};
     border-bottom-left-radius: ${themeGet('radius')}px;
     border-bottom-right-radius: ${themeGet('radius')}px;
   `,

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -14,7 +14,7 @@ const TabsProvider = createComponent({
 const TabList = createComponent({
   name: 'TabList',
   tag: 'ul',
-  style: ({ vertical }) => css`
+  style: ({ vertical, theme }) => css`
     display: flex;
     margin: 0;
     padding: 0;
@@ -23,7 +23,7 @@ const TabList = createComponent({
 
     ${!vertical &&
       css`
-        border-bottom: 1px solid #dfe3e8;
+        border-bottom: 1px solid ${theme.colors.greyLighter};
       `};
   `,
 });
@@ -69,13 +69,13 @@ const TabTitle = createComponent({
   tag: 'span',
   style: ({ active, vertical, theme }) => css`
     display: block;
-    color: ${active ? '#212b36' : '#637381'};
+    color: ${active ? theme.colors.greyDarkest : theme.colors.greyDark};
     padding: ${vertical ? '8px 12px 8px 8px' : '12px 8px'};
     border-${vertical ? 'left' : 'bottom'}: 4px solid ${active ? theme.colors.primary : 'transparent'};
 
     &::hover {
       color: #212b36;
-      border-color: ${active ? theme.colors.primary : '#d9dee3'};
+      border-color: ${active ? theme.colors.primary : theme.colors.greyLight};
     }
   `,
 });

--- a/src/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -23,7 +23,7 @@ exports[`<Tabs /> renders 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  border-bottom: 1px solid #dfe3e8;
+  border-bottom: 1px solid #F4F4F4;
 }
 
 .c2 {
@@ -65,26 +65,26 @@ exports[`<Tabs /> renders 1`] = `
 
 .c4 {
   display: block;
-  color: #212b36;
+  color: #494D55;
   padding: 12px 8px;
-  border-bottom: 4px solid #2DAAF2;
+  border-bottom: 4px solid #226EFF;
 }
 
 .c4::hover {
   color: #212b36;
-  border-color: #2DAAF2;
+  border-color: #226EFF;
 }
 
 .c5 {
   display: block;
-  color: #637381;
+  color: #A4A6AA;
   padding: 12px 8px;
   border-bottom: 4px solid transparent;
 }
 
 .c5::hover {
   color: #212b36;
-  border-color: #d9dee3;
+  border-color: #E8E9EA;
 }
 
 .c6 {

--- a/src/theme.js
+++ b/src/theme.js
@@ -4,39 +4,57 @@ export default (overrides = {}) => {
 
   const colors = Object.assign(
     {
-      primaryDark: '#002BA0',
-      primary: '#2DAAF2',
-      primaryLight: '#9FB8FC',
+      default: '#494D55',
+      black: '#1B202B',
+      white: '#FFFFFF',
 
-      grayDark: '#43526D',
-      grayMid: '#8E97A7',
-      gray: '#8E97A7',
-      grayLight: '#DEE0E4',
-      grayLightest: '#F1F4F6',
+      greyLightest: '#F8F8F9',
+      greyLighter: '#F4F4F4',
+      greyLight: '#E8E9EA',
+      grey: '#D1D2D5',
+      greyDark: '#A4A6AA',
+      greyDarker: '#767980',
+      greyDarkest: '#494D55',
 
-      redDark: '#B22327',
+      primaryLightest: '#CADCFF',
+      primaryLight: '#4D89FF',
+      primary: '#226EFF',
+      primaryDark: '#0958F3',
+
+      secondaryLightest: '#DDF5ED',
+      secondaryLight: '#42C79B',
+      secondary: '#21B986',
+      secondaryDark: '#00AC74',
+
+      redLightest: '#FFD7D8',
+      redLight: '#FE7B7E',
       red: '#FD575D',
-      redLight: ' #FFCECF',
+      redDark: '#F23338',
 
-      blueDark: '#006DC1',
-      blue: '#0747A5',
-      blueLight: '#C8E8FF',
+      purpleLightest: '#EBDCFC',
+      purpleLight: '#BB8AF6',
+      purple: '#A262F0',
+      purpleDark: '#8B3FE7',
 
-      greenDark: '#196C1C',
-      green: '#00D684',
-      greenLight: '#B4F7DE',
+      orangeLightest: '#FFE6D4',
+      orangeLight: '#FFAA70',
+      orange: '#FF954D',
+      orangeDark: '#EE7523',
 
-      orangeDark: '#BB520B',
-      orange: '#FFAA70',
-      orangeLight: '#FFD8BD',
-
-      yellowDark: '#F1BC0B',
+      yellowLightest: '#FFF6D6',
+      yellowLight: '#FFE075',
       yellow: '#FED23D',
-      yellowLight: '#FFEDB1',
+      yellowDark: '#F1BC0B',
 
-      purpleDark: '#8530FD',
-      purple: '#9D58FE',
-      purpleLight: '#DFC8FF',
+      blueLightest: '#CADCFF',
+      blueLight: '#4D89FF',
+      blue: '#226EFF',
+      blueDark: '#0958F3',
+
+      greenLightest: '#DDF5ED',
+      greenLight: '#42C79B',
+      green: '#21B986',
+      greenDark: '#00AC74',
     },
     overrides.colors
   );
@@ -50,54 +68,54 @@ export default (overrides = {}) => {
   const buttonVariants = {
     primary: {
       backgroundColor: colors.primary,
-      fontColor: 'white',
+      fontColor: colors.white,
     },
     success: {
       backgroundColor: colors.green,
-      fontColor: 'white',
+      fontColor: colors.white,
     },
     danger: {
       backgroundColor: colors.red,
-      fontColor: 'white',
+      fontColor: colors.white,
     },
     warning: {
       backgroundColor: colors.orange,
-      fontColor: 'white',
+      fontColor: colors.white,
     },
     info: {
       backgroundColor: colors.blue,
-      fontColor: 'white',
+      fontColor: colors.white,
     },
-    gray: {
-      backgroundColor: colors.grayLight,
-      fontColor: colors.grayDark,
+    grey: {
+      backgroundColor: colors.greyLight,
+      fontColor: colors.greyDarkest,
     },
   };
 
   const badgeVariants = {
     primary: {
-      backgroundColor: colors.primaryLight,
+      backgroundColor: colors.primaryLightest,
       fontColor: colors.primaryDark,
     },
     success: {
-      backgroundColor: colors.greenLight,
+      backgroundColor: colors.greenLightest,
       fontColor: colors.greenDark,
     },
     danger: {
-      backgroundColor: colors.redLight,
+      backgroundColor: colors.redLightest,
       fontColor: colors.redDark,
     },
     warning: {
-      backgroundColor: colors.orangeLight,
+      backgroundColor: colors.orangeLightest,
       fontColor: colors.orangeDark,
     },
     info: {
-      backgroundColor: colors.blueLight,
+      backgroundColor: colors.blueLightest,
       fontColor: colors.blueDark,
     },
-    gray: {
-      backgroundColor: colors.grayLight,
-      fontColor: colors.grayDark,
+    grey: {
+      backgroundColor: colors.greyLight,
+      fontColor: colors.greyDarker,
     },
   };
 


### PR DESCRIPTION
There are a lot of existing PRs that rely on the colors being updated. Instead of making those changes on every PR, I made this to update colors in one sweep.

Colors were changed for specific components because `gray =>  grey` as well as basic theme file changes. If any components match the Figma file (as far as colors go), it is purely coincidence. Those specific changes will be made in their respective PRs.

Colors like `green` and `blue` were kept to mitigate breaking changes. Coincidentally, our primary and secondary colors are blue/green so it's only natural to make those the blue and green for our color scheme. But I wanted to leave those colors in to make this work out of the box.