### PR TITLE
feat: Button variant styling proposal

### DIFF
--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -7,7 +7,7 @@ import { getComponentVariant, createComponent } from '../utils';
 const StyledAlert = createComponent({
   name: 'Alert',
   style: ({ variant, theme }) => {
-    const { backgroundColor, fontColor } = getComponentVariant(theme, 'Alert', variant);
+    const variantStyles = getComponentVariant(theme, 'Alert', variant);
 
     return css`
       padding: 1rem;
@@ -15,16 +15,14 @@ const StyledAlert = createComponent({
       border: 0;
       font-size: 14px;
       font-family: ${theme.typography.fontFamily || 'inherit'};
-      border-radius: ${theme.elementRadius}px;
-      border-left: 4px solid ${fontColor};
-      background: ${backgroundColor};
-      color: ${fontColor};
+      border-radius: ${theme.radius}px;
 
       a {
         color: inherit;
         text-decoration: underline;
       }
 
+      ${variantStyles}
       ${space};
     `;
   },

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -9,16 +9,14 @@ const StyledBadge = createComponent({
   tag: 'span',
   style: ({ variant, theme, size }) => {
     const variantStyles = getComponentVariant(theme, 'Badge', variant);
-    const { fontSize, paddingVertical, paddingHorizontal } = getComponentSize(theme, 'Badge', size);
+    const sizeStyles = getComponentSize(theme, 'Badge', size);
 
     return css`
-      padding: ${paddingVertical}px ${paddingHorizontal}px;
-      font-size: ${fontSize}px;
       font-family: inherit;
       font-weight: bold;
-      border-radius: ${fontSize}px;
 
-      ${variantStyles}
+      ${variantStyles};
+      ${sizeStyles};
       ${space};
     `;
   },

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -8,7 +8,7 @@ const StyledBadge = createComponent({
   name: 'Badge',
   tag: 'span',
   style: ({ variant, theme, size }) => {
-    const { backgroundColor, fontColor } = getComponentVariant(theme, 'Badge', variant);
+    const variantStyles = getComponentVariant(theme, 'Badge', variant);
     const { fontSize, paddingVertical, paddingHorizontal } = getComponentSize(theme, 'Badge', size);
 
     return css`
@@ -17,8 +17,8 @@ const StyledBadge = createComponent({
       font-family: inherit;
       font-weight: bold;
       border-radius: ${fontSize}px;
-      background: ${backgroundColor};
-      color: ${fontColor};
+
+      ${variantStyles}
       ${space};
     `;
   },

--- a/src/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/Badge/__snapshots__/Badge.spec.js.snap
@@ -3,13 +3,13 @@
 exports[`Badge 1`] = `
 <DocumentFragment>
   .c0 {
-  padding: 5px 10px;
-  font-size: 14px;
   font-family: inherit;
   font-weight: bold;
-  border-radius: 14px;
   background-color: #CADCFF;
   color: #0958F3;
+  font-size: 14px;
+  border-radius: 14px;
+  padding: 5px 10px;
 }
 
 <span

--- a/src/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/Badge/__snapshots__/Badge.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Badge 1`] = `
   font-family: inherit;
   font-weight: bold;
   border-radius: 14px;
-  background: #CADCFF;
+  background-color: #CADCFF;
   color: #0958F3;
 }
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -15,7 +15,7 @@ const spinKeyframes = keyframes`
     transform: rotate(360deg);
 }`;
 
-const loadingCss = ({ height, borderColor, fontColor, backgroundColor, outline }) => css`
+const loadingCss = (height, color) => css`
   color: transparent !important;
   pointer-events: none;
   position: relative;
@@ -25,11 +25,9 @@ const loadingCss = ({ height, borderColor, fontColor, backgroundColor, outline }
   &::after {
     display: block;
     content: '';
-    border-color: ${outline ? backgroundColor : borderColor || fontColor};
     animation: ${spinKeyframes} 820ms infinite linear;
-    border-width: 2px;
-    border-style: solid;
     border-radius: 100%;
+    border: 2px solid ${color};
     border-right-color: transparent;
     border-top-color: transparent;
     left: 50%;
@@ -45,29 +43,8 @@ const loadingCss = ({ height, borderColor, fontColor, backgroundColor, outline }
 const StyledButton = createComponent({
   name: 'Button',
   tag: 'button',
-  style: ({
-    hasText,
-    leftIcon,
-    rightIcon,
-    variant,
-    size,
-    theme,
-    block,
-    disabled,
-    loading,
-    text,
-    outline,
-    borderRadius,
-  }) => {
-    const {
-      textColor,
-      borderColor,
-      backgroundColor,
-      fontColor,
-      hover,
-      active,
-      disabled: disabledState,
-    } = getComponentVariant(theme, 'Button', variant);
+  style: ({ hasText, leftIcon, rightIcon, variant, size, theme, block, disabled, loading, borderRadius }) => {
+    const variantStyles = getComponentVariant(theme, 'Button', variant);
     const { fontSize, height } = getComponentSize(theme, 'Button', size);
 
     return css`
@@ -81,15 +58,11 @@ const StyledButton = createComponent({
       appearance: none;
       border-radius: ${borderRadius || theme.radius}px;
       pointer-events: ${disabled ? 'none' : 'auto'};
-      color: ${outline ? backgroundColor : fontColor};
       height: ${height}px;
-      padding: 0 16px;
+      padding: 0 ${height / 2}px;
       font-size: ${fontSize}px;
       width: ${block ? '100%' : 'auto'};
-      background: ${outline ? 'transparent' : backgroundColor};
-      border-color: ${outline ? backgroundColor : borderColor || backgroundColor};
-      border-style: solid;
-      border-width: 1px;
+      border: 1px solid transparent;
       transition: 175ms;
       white-space: nowrap;
       user-select: none;
@@ -110,55 +83,13 @@ const StyledButton = createComponent({
           }
         `}
 
-      ${loading && loadingCss({ height, fontColor, backgroundColor, borderColor, outline })};
-
-      &:hover {
-        background-color: ${backgroundColor};
-        border-color: ${borderColor || backgroundColor};
-        color: ${fontColor};
-
-        ${hover &&
-          css`
-            background-color: ${hover.backgroundColor || backgroundColor};
-            border-color: ${hover.borderColor || hover.backgroundColor || backgroundColor};
-            color: ${hover.fontColor || fontColor};
-          `}
-      }
-
-      &:active {
-        background: ${backgroundColor};
-        border-color: ${borderColor || backgroundColor};
-        color: ${fontColor};
-
-        ${active &&
-          css`
-            background-color: ${active.backgroundColor || backgroundColor};
-            border-color: ${active.borderColor || active.backgroundColor || backgroundColor};
-            color: ${active.fontColor || fontColor};
-          `}
-      }
-
       &[disabled] {
         pointer-events: none;
-        background: ${backgroundColor};
-        border-color: ${borderColor || backgroundColor};
-        color: ${fontColor};
-
-        ${disabledState &&
-          css`
-            background-color: ${disabledState.backgroundColor || backgroundColor};
-            border-color: ${disabledState.borderColor || disabledState.backgroundColor || backgroundColor};
-            color: ${disabledState.fontColor || fontColor};
-          `}
+        opacity: 0.75;
       }
 
-      ${text &&
-        css`
-          background-color: transparent !important;
-          border-color: transparent !important;
-          color: ${textColor || backgroundColor} !important;
-        `}
-
+      ${loading && loadingCss(height, variantStyles.color)};
+      ${variantStyles}
       ${space};
     `;
   },
@@ -183,7 +114,6 @@ Button.propTypes = {
   block: PropTypes.bool,
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
-  text: PropTypes.bool,
   leftIcon: PropTypes.string,
   leftIconProps: PropTypes.shape(),
   rightIcon: PropTypes.string,
@@ -197,7 +127,6 @@ Button.defaultProps = {
   block: false,
   disabled: false,
   loading: false,
-  text: false,
 };
 
 const verticalCss = ({ sizes, vertical, borderRadius }) => {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -45,22 +45,19 @@ const StyledButton = createComponent({
   tag: 'button',
   style: ({ hasText, leftIcon, rightIcon, variant, size, theme, block, disabled, loading, borderRadius }) => {
     const variantStyles = getComponentVariant(theme, 'Button', variant);
-    const { fontSize, height } = getComponentSize(theme, 'Button', size);
+    const sizeStyles = getComponentSize(theme, 'Button', size);
 
     return css`
-      font-family: inherit;
       display: inline-block;
-      text-align: center;
       cursor: pointer;
       text-transform: capitalize;
-      font-weight: bold;
+      text-align: center;
       text-decoration: none;
+      font-family: inherit;
+      font-weight: bold;
       appearance: none;
       border-radius: ${borderRadius || theme.radius}px;
       pointer-events: ${disabled ? 'none' : 'auto'};
-      height: ${height}px;
-      padding: 0 ${height / 2}px;
-      font-size: ${fontSize}px;
       width: ${block ? '100%' : 'auto'};
       border: 1px solid transparent;
       transition: 175ms;
@@ -88,8 +85,9 @@ const StyledButton = createComponent({
         opacity: 0.75;
       }
 
-      ${loading && loadingCss(height, variantStyles.color)};
+      ${loading && loadingCss(sizeStyles.height, variantStyles.color)};
       ${variantStyles}
+      ${sizeStyles};
       ${space};
     `;
   },

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -22,20 +22,9 @@ Custom button styles for actions in forms, dialogs, and more with support for mu
 <Playground>
   <Button.Group justifyContent="space-around">
     <Button>Primary Button</Button>
-    <Button outline>Outline Button</Button>
-  </Button.Group>
-</Playground>
-
-## Text
-
-Use the `text` prop to use a Text Button.
-
-<Playground>
-  <Button.Group justifyContent="space-around">
-    <Button text>Primary Text Button</Button>
-    <Button text variant="grey">Grey Text Button</Button>
-    <Button text variant="success">Success Text Button</Button>
-    <Button text variant="danger">Danger Text Button</Button>
+    <Button variant="secondary">Secondary Button</Button>
+    <Button variant="grey">Secondary Button</Button>
+    <Button variant="primaryText">Text Button</Button>
   </Button.Group>
 </Playground>
 
@@ -45,8 +34,6 @@ Buttons may contain a `leftIcon` or `rightIcon` prop. Additional props may be pa
 <Playground>
   <Button.Group justifyContent="space-around">
     <Button leftIcon="alert">Primary Button</Button>
-    <Button rightIcon="alert">Primary Button</Button>
-    <Button variant="success" leftIcon="alert-circle">Success Button</Button>
     <Button variant="success" rightIcon="alert-circle" rightIconProps={{ size: 24 }}>Success Button</Button>
   </Button.Group>
 </Playground>

--- a/src/Button/Button.mdx
+++ b/src/Button/Button.mdx
@@ -23,7 +23,7 @@ Custom button styles for actions in forms, dialogs, and more with support for mu
   <Button.Group justifyContent="space-around">
     <Button>Primary Button</Button>
     <Button variant="secondary">Secondary Button</Button>
-    <Button variant="grey">Secondary Button</Button>
+    <Button variant="grey">Grey Button</Button>
     <Button variant="primaryText">Text Button</Button>
   </Button.Group>
 </Playground>
@@ -133,6 +133,6 @@ Add the `loading` prop for loading button state style.
 <Playground>
   <Button.Group justifyContent="space-around">
     <Button loading>I'm loading</Button>
-    <Button loading outline>I'm loading</Button>
+    <Button loading variant="secondary">I'm loading</Button>
   </Button.Group>
 </Playground>

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -35,15 +35,11 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
   appearance: none;
   border-radius: 8px;
   pointer-events: auto;
-  color: #FFFFFF;
   height: 40px;
-  padding: 0 16px;
+  padding: 0 20px;
   font-size: 16px;
   width: auto;
-  background: #226EFF;
-  border-color: #226EFF;
-  border-style: solid;
-  border-width: 1px;
+  border: 1px solid transparent;
   -webkit-transition: 175ms;
   transition: 175ms;
   white-space: nowrap;
@@ -51,34 +47,25 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.c1:hover {
   background-color: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
-  background-color: #4D89FF;
-  border-color: #4D89FF;
-  color: #FFFFFF;
-}
-
-.c1:active {
-  background: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
-  background-color: #0958F3;
-  border-color: #0958F3;
   color: #FFFFFF;
 }
 
 .c1[disabled] {
   pointer-events: none;
-  background: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
+  opacity: 0.75;
+}
+
+.c1:hover {
+  background-color: #4D89FF;
+}
+
+.c1:active {
+  background-color: #0958F3;
+}
+
+.c1:disabled {
   background-color: #CADCFF;
-  border-color: #CADCFF;
-  color: #FFFFFF;
 }
 
 <div
@@ -138,15 +125,11 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
   appearance: none;
   border-radius: 8px;
   pointer-events: auto;
-  color: #FFFFFF;
   height: 40px;
-  padding: 0 16px;
+  padding: 0 20px;
   font-size: 16px;
   width: auto;
-  background: #226EFF;
-  border-color: #226EFF;
-  border-style: solid;
-  border-width: 1px;
+  border: 1px solid transparent;
   -webkit-transition: 175ms;
   transition: 175ms;
   white-space: nowrap;
@@ -154,34 +137,25 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-}
-
-.c1:hover {
   background-color: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
-  background-color: #4D89FF;
-  border-color: #4D89FF;
-  color: #FFFFFF;
-}
-
-.c1:active {
-  background: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
-  background-color: #0958F3;
-  border-color: #0958F3;
   color: #FFFFFF;
 }
 
 .c1[disabled] {
   pointer-events: none;
-  background: #226EFF;
-  border-color: #226EFF;
-  color: #FFFFFF;
+  opacity: 0.75;
+}
+
+.c1:hover {
+  background-color: #4D89FF;
+}
+
+.c1:active {
+  background-color: #0958F3;
+}
+
+.c1:disabled {
   background-color: #CADCFF;
-  border-color: #CADCFF;
-  color: #FFFFFF;
 }
 
 <div

--- a/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/Dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -22,22 +22,19 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
 }
 
 .c1 {
-  font-family: inherit;
   display: inline-block;
-  text-align: center;
   cursor: pointer;
   text-transform: capitalize;
-  font-weight: bold;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  font-family: inherit;
+  font-weight: bold;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   border-radius: 8px;
   pointer-events: auto;
-  height: 40px;
-  padding: 0 20px;
-  font-size: 16px;
   width: auto;
   border: 1px solid transparent;
   -webkit-transition: 175ms;
@@ -49,6 +46,9 @@ exports[`<Dropdown /> only renders trigger on mount 1`] = `
   user-select: none;
   background-color: #226EFF;
   color: #FFFFFF;
+  font-size: 16px;
+  height: 40px;
+  padding: 0 16px;
 }
 
 .c1[disabled] {
@@ -112,22 +112,19 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
 }
 
 .c1 {
-  font-family: inherit;
   display: inline-block;
-  text-align: center;
   cursor: pointer;
   text-transform: capitalize;
-  font-weight: bold;
+  text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
+  font-family: inherit;
+  font-weight: bold;
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
   border-radius: 8px;
   pointer-events: auto;
-  height: 40px;
-  padding: 0 20px;
-  font-size: 16px;
   width: auto;
   border: 1px solid transparent;
   -webkit-transition: 175ms;
@@ -139,6 +136,9 @@ exports[`<Dropdown /> opens menu with focus when trigger is clicked 1`] = `
   user-select: none;
   background-color: #226EFF;
   color: #FFFFFF;
+  font-size: 16px;
+  height: 40px;
+  padding: 0 16px;
 }
 
 .c1[disabled] {

--- a/src/theme.js
+++ b/src/theme.js
@@ -69,8 +69,8 @@ export default (overrides = {}) => {
 
   const buttonVariants = {
     primary: {
-      color: colors.white,
       backgroundColor: colors.primary,
+      color: colors.white,
       '&:hover': {
         backgroundColor: colors.primaryLight,
       },
@@ -82,31 +82,31 @@ export default (overrides = {}) => {
       },
     },
     primaryText: {
-      color: colors.primary,
       backgroundColor: 'transparent',
       borderColor: 'transparent',
+      color: colors.primary,
     },
     secondary: {
-      color: colors.primary,
       backgroundColor: colors.white,
       borderColor: colors.primary,
+      color: colors.primary,
       '&:hover': {
-        color: colors.white,
         backgroundColor: colors.primary,
+        color: colors.white,
       },
       '&:active': {
-        color: colors.white,
         backgroundColor: colors.primaryDark,
+        color: colors.white,
       },
       '&:disabled': {
-        color: colors.primaryLightest,
         borderColor: colors.primaryLightest,
+        color: colors.primaryLightest,
       },
     },
     grey: {
-      color: colors.greyDarkest,
       backgroundColor: colors.white,
       borderColor: colors.grey,
+      color: colors.greyDarkest,
       '&:hover': {
         borderColor: colors.greyDark,
       },
@@ -114,14 +114,14 @@ export default (overrides = {}) => {
         backgroundColor: colors.greyLight,
       },
       '&:disabled': {
-        color: colors.grey,
         borderColor: colors.grey,
+        color: colors.grey,
       },
     },
     greyText: {
-      color: colors.grey,
       backgroundColor: 'transparent',
       borderColor: 'transparent',
+      color: colors.grey,
     },
     success: {
       color: colors.white,
@@ -137,8 +137,8 @@ export default (overrides = {}) => {
       },
     },
     warning: {
-      color: colors.white,
       backgroundColor: colors.orange,
+      color: colors.white,
       '&:hover': {
         backgroundColor: colors.orangeLight,
       },
@@ -150,8 +150,8 @@ export default (overrides = {}) => {
       },
     },
     danger: {
-      color: colors.white,
       backgroundColor: colors.red,
+      color: colors.white,
       '&:hover': {
         backgroundColor: colors.redLight,
       },
@@ -163,8 +163,8 @@ export default (overrides = {}) => {
       },
     },
     info: {
-      color: colors.white,
       backgroundColor: colors.blue,
+      color: colors.white,
     },
   };
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -250,31 +250,34 @@ export default (overrides = {}) => {
         sm: {
           fontSize: 14,
           height: 32,
+          padding: '0 12px',
         },
         md: {
           fontSize: 16,
           height: 40,
+          padding: '0 16px',
         },
         lg: {
           fontSize: 16,
           height: 48,
+          padding: '0 20px',
         },
       },
       Badge: {
         sm: {
           fontSize: 12,
-          paddingVertical: 4,
-          paddingHorizontal: 8,
+          borderRadius: 12,
+          padding: '4px 8px',
         },
         md: {
           fontSize: 14,
-          paddingVertical: 5,
-          paddingHorizontal: 10,
+          borderRadius: 14,
+          padding: '5px 10px',
         },
         lg: {
           fontSize: 16,
-          paddingVertical: 6,
-          paddingHorizontal: 12,
+          borderRadius: 16,
+          padding: '6px 12px',
         },
       },
     },

--- a/src/theme.js
+++ b/src/theme.js
@@ -69,121 +69,129 @@ export default (overrides = {}) => {
 
   const buttonVariants = {
     primary: {
+      color: colors.white,
       backgroundColor: colors.primary,
-      fontColor: colors.white,
-      hover: {
+      '&:hover': {
         backgroundColor: colors.primaryLight,
       },
-      active: {
+      '&:active': {
         backgroundColor: colors.primaryDark,
       },
-      disabled: {
+      '&:disabled': {
         backgroundColor: colors.primaryLightest,
       },
     },
+    primaryText: {
+      color: colors.primary,
+      backgroundColor: 'transparent',
+      borderColor: 'transparent',
+    },
     secondary: {
+      color: colors.primary,
       backgroundColor: colors.white,
-      fontColor: colors.primary,
       borderColor: colors.primary,
-      textColor: colors.primary,
-      hover: {
+      '&:hover': {
+        color: colors.white,
         backgroundColor: colors.primary,
-        fontColor: colors.white,
       },
-      active: {
+      '&:active': {
+        color: colors.white,
         backgroundColor: colors.primaryDark,
-        fontColor: colors.white,
       },
-      disabled: {
-        fontColor: colors.primaryLightest,
+      '&:disabled': {
+        color: colors.primaryLightest,
         borderColor: colors.primaryLightest,
       },
     },
     grey: {
+      color: colors.greyDarkest,
       backgroundColor: colors.white,
-      fontColor: colors.greyDarkest,
       borderColor: colors.grey,
-      textColor: colors.greyDarkest,
-      hover: {
+      '&:hover': {
         borderColor: colors.greyDark,
       },
-      active: {
+      '&:active': {
         backgroundColor: colors.greyLight,
       },
-      disabled: {
-        fontColor: colors.grey,
+      '&:disabled': {
+        color: colors.grey,
         borderColor: colors.grey,
       },
     },
+    greyText: {
+      color: colors.grey,
+      backgroundColor: 'transparent',
+      borderColor: 'transparent',
+    },
     success: {
+      color: colors.white,
       backgroundColor: colors.secondary,
-      fontColor: colors.white,
-      hover: {
+      '&:hover': {
         backgroundColor: colors.secondaryLight,
       },
-      active: {
+      '&:active': {
         backgroundColor: colors.secondaryDark,
       },
-      disabled: {
+      '&:disabled': {
         backgroundColor: colors.secondaryLightest,
       },
     },
     warning: {
+      color: colors.white,
       backgroundColor: colors.orange,
-      fontColor: colors.white,
-      hover: {
+      '&:hover': {
         backgroundColor: colors.orangeLight,
       },
-      active: {
+      '&:active': {
         backgroundColor: colors.orangeDark,
       },
-      disabled: {
+      '&:disabled': {
         backgroundColor: colors.orangeLightest,
       },
     },
     danger: {
+      color: colors.white,
       backgroundColor: colors.red,
-      fontColor: colors.white,
-      hover: {
+      '&:hover': {
         backgroundColor: colors.redLight,
       },
-      active: {
+      '&:active': {
         backgroundColor: colors.redDark,
       },
-      disabled: {
+      '&:disabled': {
         backgroundColor: colors.redLightest,
       },
     },
     info: {
+      color: colors.white,
       backgroundColor: colors.blue,
-      fontColor: colors.white,
     },
   };
 
   const badgeVariants = {
     primary: {
       backgroundColor: colors.primaryLightest,
-      fontColor: colors.primaryDark,
+      color: colors.primaryDark,
     },
     success: {
       backgroundColor: colors.greenLightest,
-      fontColor: colors.greenDark,
+      color: colors.greenDark,
     },
     danger: {
       backgroundColor: colors.redLightest,
-      fontColor: colors.redDark,
+      color: colors.redDark,
     },
     warning: {
       backgroundColor: colors.orangeLightest,
-      fontColor: colors.orangeDark,
+      color: colors.orangeDark,
     },
     info: {
       backgroundColor: colors.blueLightest,
-      fontColor: colors.blueDark,
+      color: colors.blueDark,
     },
     grey: {
       backgroundColor: colors.greyLight,
-      fontColor: colors.greyDarker,
+      color: colors.greyDarker,
     },
   };
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -85,6 +85,9 @@ export default (overrides = {}) => {
       backgroundColor: 'transparent',
       borderColor: 'transparent',
       color: colors.primary,
+      '&:hover': {
+        color: colors.primaryDark,
+      },
     },
     secondary: {
       backgroundColor: colors.white,
@@ -122,6 +125,9 @@ export default (overrides = {}) => {
       backgroundColor: 'transparent',
       borderColor: 'transparent',
       color: colors.grey,
+      '&:hover': {
+        color: colors.greyDark,
+      },
     },
     success: {
       color: colors.white,


### PR DESCRIPTION
## Summary

The logic to determine Button styles felt slightly cumbersome. Rather than trying to be too tricky on how to handle different button styles, e.g. outlines, text only, colors, I propose we configure every variation as a variant, with naming conventions such as `colorText` or `colorOutline`. The `variant` blocks in the theme are now fully compatible `styled-components` objects. 

They can also be defined as a function which can receive the button props, in case any extra logic is needed to determine styling.

![Screen Shot 2019-08-21 at 12 47 30 PM](https://user-images.githubusercontent.com/14184138/63463369-dd6e6b00-c411-11e9-82a3-7598615aedb9.png)