### PR TITLE
fix(Button): Centers text within full-width button

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -98,7 +98,7 @@ const renderIcon = (icon, props) => <Icon name={icon} {...props} />;
 /** Custom button styles for actions in forms, dialogs, and more with support for multiple sizes, states, and more. We include several predefined button styles, each serving its own semantic purpose, with a few extras thrown in for more control. */
 const Button = React.forwardRef(({ children, leftIcon, leftIconProps, rightIcon, rightIconProps, ...rest }, ref) => (
   <StyledButton ref={ref} hasText={!!children} leftIcon={leftIcon} rightIcon={rightIcon} {...rest}>
-    <Flex alignItems="center">
+    <Flex alignItems="center" justifyContent="center">
       {leftIcon && renderIcon(leftIcon, leftIconProps)}
       {children}
       {rightIcon && renderIcon(rightIcon, rightIconProps)}

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -61,3 +61,5 @@ export const Loading = () => (
     </Button>
   </Button.Group>
 );
+
+export const FullWidth = () => <Button block>Full Width</Button>;


### PR DESCRIPTION
Text on full width buttons was aligning to the left. I can't think of a time where this would be desirable. So, I justified the content to the center.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/10860014/64572843-97c90200-d32e-11e9-8c33-5bcecd334205.png)|![image](https://user-images.githubusercontent.com/10860014/64572818-854ec880-d32e-11e9-9269-84cd1c14d681.png)|

Added to Button story as well.
