### PR TITLE
fix(Checkbox):  Support for long labels

### DIFF
--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -142,7 +142,7 @@ export class Checkbox extends React.Component {
           onChange={this.handleChange}
         />
 
-        <Flex alignItems="top">
+        <Flex>
           <StyledIcon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
           {label && (

--- a/src/Form/Checkbox.js
+++ b/src/Form/Checkbox.js
@@ -22,7 +22,7 @@ const CheckboxContainer = createComponent({
   `,
 });
 
-const StyledInput = createComponent({
+const HiddenInput = createComponent({
   name: 'CheckboxInput',
   tag: 'input',
   style: css`
@@ -41,6 +41,7 @@ const StyledLabel = createComponent({
   as: Flex,
   style: ({ fontSize }) => css`
     margin-left: 8px;
+    margin-top: 4px;
     font-size: ${fontSize}px;
   `,
 });
@@ -132,7 +133,7 @@ export class Checkbox extends React.Component {
 
     return (
       <CheckboxContainer horizontal={horizontal} style={styles.CheckboxContainer}>
-        <StyledInput
+        <HiddenInput
           id={id}
           name={name}
           type="checkbox"
@@ -141,7 +142,7 @@ export class Checkbox extends React.Component {
           onChange={this.handleChange}
         />
 
-        <Flex alignItems="center">
+        <Flex alignItems="top">
           <StyledIcon size={iconSize} color={checked ? colorOn : colorOff} name={checked ? iconOn : iconOff} />
 
           {label && (

--- a/src/Form/Checkbox.stories.js
+++ b/src/Form/Checkbox.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Box from '../Box';
 import { Checkbox } from './Checkbox';
 
 export default {
@@ -6,11 +7,21 @@ export default {
   component: Checkbox,
 };
 
-export const Basic = () => <Checkbox id="checkbox" name="checkbox" />;
+export const Basic = () => <Checkbox id="checkbox" name="checkbox" label="I'm a checkbox" />;
+
+export const LongText = () => (
+  <Box width={300}>
+    <Checkbox
+      id="checkbox"
+      name="checkbox"
+      label="'Cause I've been goin' off and they don't know when it's stoppin'
+And when you get to toppin', I see that you've been learnin'"
+    />
+  </Box>
+);
 
 export const Colors = () => (
   <>
-    <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" />
-    <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" value />
+    <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" label="Red Off, Green On" />
   </>
 );

--- a/src/Form/Checkbox.stories.js
+++ b/src/Form/Checkbox.stories.js
@@ -21,7 +21,5 @@ And when you get to toppin', I see that you've been learnin'"
 );
 
 export const Colors = () => (
-  <>
-    <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" label="Red Off, Green On" />
-  </>
+  <Checkbox id="checkbox" name="checkbox" colorOn="green" colorOff="red" label="Red Off, Green On" />
 );


### PR DESCRIPTION
When we have long labels, or when they wrap on mobile, the checkbox icon would become vertically centered, which looks weird.

### Before
<img width="308" alt="Screen Shot 2019-09-09 at 9 04 35 PM" src="https://user-images.githubusercontent.com/14184138/64583375-84756100-d345-11e9-844b-42037aa7fd77.png">

### After
<img width="306" alt="Screen Shot 2019-09-09 at 9 02 03 PM" src="https://user-images.githubusercontent.com/14184138/64583382-88a17e80-d345-11e9-9013-2bf46128da9b.png">
<img width="159" alt="Screen Shot 2019-09-09 at 9 02 07 PM" src="https://user-images.githubusercontent.com/14184138/64583388-8b03d880-d345-11e9-944a-7c2888c423bd.png">
