### PR TITLE
fix(Flex): Forwards ref to children

### DIFF
--- a/src/Flex/Flex.js
+++ b/src/Flex/Flex.js
@@ -20,7 +20,7 @@ const BaseFlex = createComponent({
 
 /** Quickly manage the layout, alignment, and sizing of grid columns, navigation, components, and more with a full suite of responsive flexbox utilities. For more complex implementations, custom CSS may be necessary.
  */
-const Flex = props => <BaseFlex {...props} />;
+const Flex = React.forwardRef((props, ref) => <BaseFlex {...props} ref={ref} />);
 
 Flex.displayName = 'Flex';
 


### PR DESCRIPTION
Was having an issue where if the component had a `ref` passed to it, it would be ignored since it was a functional component.

This will pass ref through.