### PR TITLE
feat(Text): New Text component; upgrade to styled-system@v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2369,6 +2369,116 @@
         }
       }
     },
+    "@styled-system/background": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
+      "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/border": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.2.tgz",
+      "integrity": "sha512-mSSxyQGXELdNSOlf4RqaOKsX+w6//zooR3p6qDj5Zgc5pIdEsJm63QLz6EST/6xBJwTX0Z1w4ExItdd6Q7rlTQ==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/color": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
+      "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
+      "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@styled-system/css": {
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.0.23.tgz",
+      "integrity": "sha512-yC3S0Iox8OTPAyrP1t5yY9nURUICcUdhVYOkwffftuxa5+txxI4qkT2e9JNCc2aaem+DG8mlXTdnYefjqge5wg=="
+    },
+    "@styled-system/flexbox": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
+      "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/grid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
+      "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/layout": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
+      "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/position": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
+      "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/prop-types": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/prop-types/-/prop-types-5.1.2.tgz",
+      "integrity": "sha512-q2hnuZrOjZdCRYvSoMF5VIDRfpqPHDSgqajoMH0iy7BszPAkZZcIC7L4PzJTIcGSBrB9OJTBitWo9s7N60tgtA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@styled-system/shadow": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
+      "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/space": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
+      "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/typography": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
+      "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/variant": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.2.tgz",
+      "integrity": "sha512-NousRWr0JQSOZS87f1N+59EUAo7ZH6/Df/iN1ZVjHr2Ntah/lPMQvAnIuqkknjoRMjJL/g1SyoQ+dP3QX0XOng==",
+      "requires": {
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/css": "^5.0.23"
+      }
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
@@ -16126,12 +16236,23 @@
       }
     },
     "styled-system": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.2.1.tgz",
-      "integrity": "sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.2.tgz",
+      "integrity": "sha512-gbiohoqYYtvg9Q6nA3EagQSouHI9ylmcKUHHaUvCQrPpnPeJlUJAvj9vfyDgsJjw/oBogggfojF1X9EShfPffg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "prop-types": "^15.6.2"
+        "@styled-system/background": "^5.1.2",
+        "@styled-system/border": "^5.1.2",
+        "@styled-system/color": "^5.1.2",
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/flexbox": "^5.1.2",
+        "@styled-system/grid": "^5.1.2",
+        "@styled-system/layout": "^5.1.2",
+        "@styled-system/position": "^5.1.2",
+        "@styled-system/shadow": "^5.1.2",
+        "@styled-system/space": "^5.1.2",
+        "@styled-system/typography": "^5.1.2",
+        "@styled-system/variant": "^5.1.2",
+        "object-assign": "^4.1.1"
       }
     },
     "stylis": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -39,7 +38,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
       "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
@@ -52,7 +50,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -127,7 +124,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
-      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.0.0",
         "@babel/template": "^7.1.0",
@@ -138,7 +134,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -165,7 +160,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -247,7 +241,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
       "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
       }
@@ -279,7 +272,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -289,8 +281,7 @@
     "@babel/parser": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-      "dev": true
+      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.2.0",
@@ -998,7 +989,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
       "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.4.4",
@@ -1009,7 +999,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
       "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.5.5",
@@ -1026,7 +1015,6 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
       "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
@@ -1090,7 +1078,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz",
       "integrity": "sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==",
-      "dev": true,
       "requires": {
         "@emotion/memoize": "0.7.2"
       }
@@ -1098,8 +1085,7 @@
     "@emotion/memoize": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.2.tgz",
-      "integrity": "sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==",
-      "dev": true
+      "integrity": "sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w=="
     },
     "@emotion/serialize": {
       "version": "0.11.10",
@@ -1151,8 +1137,7 @@
     "@emotion/unitless": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==",
-      "dev": true
+      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
     },
     "@emotion/utils": {
       "version": "0.11.2",
@@ -2758,6 +2743,15 @@
         "@types/react": "*"
       }
     },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -4021,7 +4015,6 @@
       "version": "1.10.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
       "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -4032,8 +4025,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -4595,6 +4587,12 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -4738,8 +4736,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
-      "dev": true
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -4790,7 +4787,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5951,8 +5947,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-loader": {
       "version": "3.2.0",
@@ -6026,7 +6021,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
       "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
-      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -6036,8 +6030,7 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         }
       }
     },
@@ -6195,7 +6188,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -6805,8 +6797,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.12.0",
@@ -7469,8 +7460,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -9290,8 +9280,7 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globalthis": {
       "version": "1.0.0",
@@ -9447,8 +9436,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -10228,6 +10216,12 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -10379,8 +10373,7 @@
     "is-what": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.3.1.tgz",
-      "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA==",
-      "dev": true
+      "integrity": "sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA=="
     },
     "is-whitespace-character": {
       "version": "1.0.3",
@@ -11143,8 +11136,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -11678,8 +11670,7 @@
     "memoize-one": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
-      "dev": true
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -11782,7 +11773,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.1.tgz",
       "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
-      "dev": true,
       "requires": {
         "is-what": "^3.3.1"
       }
@@ -12065,8 +12055,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -14858,6 +14847,19 @@
         }
       }
     },
+    "rollup-plugin-node-resolve": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
+      "dev": true,
+      "requires": {
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
@@ -15508,8 +15510,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -16218,7 +16219,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.3.2.tgz",
       "integrity": "sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.0.0",
@@ -16258,20 +16258,17 @@
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "dev": true
+      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q=="
     },
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "dev": true
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -16638,8 +16635,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -16764,8 +16760,7 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "trim-trailing-lines": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "release": "standard-version"
   },
   "dependencies": {
+    "@styled-system/prop-types": "^5.1.2",
     "@testing-library/react": "^9.1.3",
     "cleave.js": "~1.4.10",
     "libphonenumber-js": "^1.7.13",
@@ -41,7 +42,7 @@
     "react-popper": "^1.3.3",
     "react-portal": "^4.2.0",
     "react-transition-group": "^2.5.3",
-    "styled-system": "^3.2.1"
+    "styled-system": "^5.1.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "react-popper": "^1.3.3",
     "react-portal": "^4.2.0",
     "react-transition-group": "^2.5.3",
+    "styled-components": "^4.0.0",
     "styled-system": "^5.1.2"
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "styled-components": "^4.0.0"
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",
@@ -82,8 +82,8 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-filesize": "^6.0.1",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "standard-version": "^4.4.0",
-    "styled-components": "^4.1.3",
     "yup": "^0.26.10"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from 'rollup-plugin-babel';
 import filesize from 'rollup-plugin-filesize';
 import cjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
 import pkg from './package.json';
 
 export default {
@@ -15,10 +16,17 @@ export default {
       format: 'es',
     },
   ],
-  external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+  external: [
+    ...Object.keys(pkg.dependencies || {}).filter(dep => dep !== 'styled-components'),
+    ...Object.keys(pkg.peerDependencies || {}),
+  ],
   plugins: [
     babel({
       babelrc: true,
+    }),
+    resolve({
+      only: ['styled-components'],
+      dedupe: ['react', 'react-dom', 'styled-components'],
     }),
     cjs({
       include: 'node_modules/**',

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import { space } from 'styled-system';
+import propTypes from '@styled-system/prop-types';
 import { getComponentVariant, createComponent } from '../utils';
 
 const StyledAlert = createComponent({
@@ -29,10 +30,11 @@ const StyledAlert = createComponent({
 });
 
 /** Alerts are typically used to display meaningful copy to users - typically notifying the user of an important message. */
-const Alert = props => <StyledAlert {...props} />;
+const Alert = React.forwardRef((props, ref) => <StyledAlert {...props} ref={ref} />);
 
 Alert.propTypes = {
   variant: PropTypes.string,
+  ...propTypes.space,
 };
 
 Alert.defaultProps = {

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import { space } from 'styled-system';
+import propTypes from '@styled-system/prop-types';
 import { getComponentVariant, createComponent, getComponentSize } from '../utils';
 
 const StyledBadge = createComponent({
@@ -22,11 +23,12 @@ const StyledBadge = createComponent({
   },
 });
 
-const Badge = props => <StyledBadge {...props} />;
+const Badge = React.forwardRef((props, ref) => <StyledBadge {...props} ref={ref} />);
 
 Badge.propTypes = {
   variant: PropTypes.string,
   size: PropTypes.string,
+  ...propTypes.space,
 };
 
 Badge.defaultProps = {

--- a/src/Box/Box.js
+++ b/src/Box/Box.js
@@ -1,50 +1,28 @@
-import { css } from 'styled-components';
-import {
-  display,
-  space,
-  color,
-  height,
-  width,
-  fontSize,
-  fontWeight,
-  textAlign,
-  lineHeight,
-  alignSelf,
-  justifySelf,
-  flex,
-} from 'styled-system';
+import { compose, space, color, typography, layout, flexbox, position, background } from 'styled-system';
+import propTypes from '@styled-system/prop-types';
 import { createComponent } from '../utils';
 
 const Box = createComponent({
   name: 'Box',
-  style: css`
-  ${display}
-  ${space}
-  ${color}
-  ${fontSize}
-  ${fontWeight}
-  ${textAlign}
-  ${lineHeight}
-  ${height}
-  ${width}
-  ${flex}
-  ${alignSelf}
-  ${justifySelf}
-  `,
+  style: compose(
+    space,
+    color,
+    typography,
+    layout,
+    flexbox,
+    position,
+    background
+  ),
 });
 
 Box.propTypes = {
-  ...display.propTypes,
-  ...space.propTypes,
-  ...color.propTypes,
-  ...width.propTypes,
-  ...fontSize.propTypes,
-  ...fontWeight.propTypes,
-  ...textAlign.propTypes,
-  ...lineHeight.propTypes,
-  ...flex.propTypes,
-  ...alignSelf.propTypes,
-  ...justifySelf.propTypes,
+  ...propTypes.space,
+  ...propTypes.color,
+  ...propTypes.typography,
+  ...propTypes.layout,
+  ...propTypes.flexbox,
+  ...propTypes.position,
+  ...propTypes.background,
 };
 
 export default Box;

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -131,7 +131,7 @@ Button.defaultProps = {
 const verticalCss = ({ breakpoints, vertical, borderRadius }) => {
   const maybeNumber = parseInt(vertical, 10);
   const fallback = breakpoints[vertical] || breakpoints.sm;
-  const breakpoint = Number.isInteger(maybeNumber) ? `${maybeNumber}px` : `${fallback}px`;
+  const breakpoint = Number.isInteger(maybeNumber) ? `${maybeNumber}px` : fallback;
 
   return css`
     @media (max-width: ${breakpoint}) {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -128,9 +128,9 @@ Button.defaultProps = {
   loading: false,
 };
 
-const verticalCss = ({ sizes, vertical, borderRadius }) => {
+const verticalCss = ({ breakpoints, vertical, borderRadius }) => {
   const maybeNumber = parseInt(vertical, 10);
-  const fallback = sizes[vertical] || sizes.sm;
+  const fallback = breakpoints[vertical] || breakpoints.sm;
   const breakpoint = Number.isInteger(maybeNumber) ? `${maybeNumber}px` : `${fallback}px`;
 
   return css`
@@ -154,15 +154,7 @@ const verticalCss = ({ sizes, vertical, borderRadius }) => {
 Button.Group = createComponent({
   name: 'ButtonGroup',
   as: Flex,
-  style: ({
-    vertical = false,
-    theme: {
-      radius,
-      grid: { sizes },
-    },
-    borderRadius = radius || 2,
-    connected = false,
-  }) => css`
+  style: ({ vertical = false, theme: { radius, breakpoints }, borderRadius = radius || 2, connected = false }) => css`
     & > button:not(:first-child) {
       margin-left: 1rem;
     }
@@ -184,7 +176,7 @@ Button.Group = createComponent({
         }
       `}
 
-    ${vertical && verticalCss({ sizes, vertical, borderRadius })};
+    ${vertical && verticalCss({ breakpoints, vertical, borderRadius })};
   `,
 });
 

--- a/src/Dropdown/Dropdown.stories.js
+++ b/src/Dropdown/Dropdown.stories.js
@@ -9,21 +9,22 @@ export default {
   component: Dropdown,
 };
 
-export const Basic = () => {
-  const [ placement, setPlacement ] = useState('bottom-start')
+function BasicExample() {
+  const [placement, setPlacement] = useState('bottom-start');
   return (
     <Flex justifyContent="center">
       <Flex mr={5}>
         <RadioGroup
           label={<strong>Placement</strong>}
           value={placement}
-          choices={Object.keys(PLACEMENT_TRANSITION_ORIGINS).map(placement => ({
-            value: placement,
-            label: placement,
+          choices={Object.keys(PLACEMENT_TRANSITION_ORIGINS).map(p => ({
+            value: p,
+            label: p,
           }))}
           onChange={(_, val) => setPlacement(val)}
         />
       </Flex>
+
       <Flex alignSelf="center">
         <Dropdown
           placement={placement}
@@ -42,13 +43,17 @@ export const Basic = () => {
       </Flex>
     </Flex>
   );
-};
+}
+
+export const Basic = () => <BasicExample />;
 
 export const WithTitles = () => (
   <Flex>
     <Dropdown placement="bottom-start" width={250} trigger={<Button variant="danger">Dropdown w/Titles</Button>}>
       <Dropdown.Title>Section Title</Dropdown.Title>
-      <Dropdown.Item selected closeOnClick={false}>Dropdown Item</Dropdown.Item>
+      <Dropdown.Item selected closeOnClick={false}>
+        Dropdown Item
+      </Dropdown.Item>
       <Dropdown.Item>Dropdown Item</Dropdown.Item>
       <Dropdown.Item>Dropdown Item</Dropdown.Item>
       <Dropdown.Divider />
@@ -80,7 +85,9 @@ export const WithIcons = () => (
       <Dropdown.Divider />
       <Dropdown.Item icon="settings">Dropdown Item</Dropdown.Item>
       <Dropdown.Divider />
-      <Dropdown.Item icon="trash-can" color="red">Cancel</Dropdown.Item>
+      <Dropdown.Item icon="trash-can" color="red">
+        Cancel
+      </Dropdown.Item>
     </Dropdown>
   </Flex>
 );

--- a/src/Flex/Flex.js
+++ b/src/Flex/Flex.js
@@ -1,35 +1,24 @@
 import React from 'react';
 import { css } from 'styled-components';
-import { flexWrap, flexDirection, alignSelf, alignItems, justifyContent } from 'styled-system';
 import Box from '../Box';
 import { createComponent } from '../utils';
 
-const BaseFlex = createComponent({
+const StyledFlex = createComponent({
   name: 'Flex',
   as: Box,
   style: () => css`
     display: flex;
-
-    ${flexWrap};
-    ${flexDirection};
-    ${alignItems};
-    ${alignSelf};
-    ${justifyContent};
   `,
 });
 
 /** Quickly manage the layout, alignment, and sizing of grid columns, navigation, components, and more with a full suite of responsive flexbox utilities. For more complex implementations, custom CSS may be necessary.
  */
-const Flex = React.forwardRef((props, ref) => <BaseFlex {...props} ref={ref} />);
+const Flex = React.forwardRef((props, ref) => <StyledFlex {...props} ref={ref} />);
 
 Flex.displayName = 'Flex';
 
 Flex.propTypes = {
-  ...flexWrap.propTypes,
-  ...flexDirection.propTypes,
-  ...alignItems.propTypes,
-  ...alignSelf.propTypes,
-  ...justifyContent.propTypes,
+  ...Box.propTypes,
 };
 
 export default Flex;

--- a/src/Grid/Column.js
+++ b/src/Grid/Column.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { head } from 'lodash';
 import PropTypes from 'prop-types';
 import { css } from 'styled-components';
 import Flex from '../Flex';
@@ -7,22 +6,25 @@ import { createComponent } from '../utils';
 
 const getWidthPercent = (width, columns) => `${(width / columns) * 100}%`;
 
-const getColumnWidth = (width, columns) =>
-  width / columns !== 1
-    ? css`
-        display: block;
-        flex-basis: ${getWidthPercent(width, columns)};
-        max-width: ${getWidthPercent(width, columns)};
-      `
-    : css`
-        max-width: 100%;
-        width: 100%;
-        flex: auto;
-      `;
+const getColumnWidth = (width, columns) => {
+  if (width / columns !== 1) {
+    return css`
+      display: block;
+      flex-basis: ${getWidthPercent(width, columns)};
+      max-width: ${getWidthPercent(width, columns)};
+    `;
+  }
+
+  return css`
+    max-width: 100%;
+    width: 100%;
+    flex: auto;
+  `;
+};
 
 const getPadding = ({ collapse, gutter, theme }) => {
   if (collapse) return 0;
-  return typeof gutter === 'number' ? gutter / 2 : theme.grid.gutter / 2;
+  return typeof gutter === 'number' ? gutter / 2 : theme.gridGutter / 2;
 };
 
 const getOffset = (offset, columns) => css`
@@ -32,24 +34,27 @@ const getOffset = (offset, columns) => css`
 const StyledColumn = createComponent({
   name: 'Column',
   as: Flex,
-  style: p => {
-    const sizes = Object.keys(p.theme.grid.sizes);
-    const mediaQueries = sizes.filter(size => !!p[size]).map(
-      size =>
-        // if smallest breakpoint no query needed
-        size === head(sizes)
-          ? css`
-              ${getColumnWidth(p[size], p.theme.grid.columns)};
-              ${p[`${size}Offset`] && getOffset(p[`${size}Offset`], p.theme.grid.columns)};
-            `
-          : // all other breakpoints use a media query
-            css`
-              @media (min-width: ${p.theme.grid.sizes[size]}px) {
-                ${getColumnWidth(p[size], p.theme.grid.columns)};
-                ${p[`${size}Offset`] !== undefined && getOffset(p[`${size}Offset`], p.theme.grid.columns)};
-              }
-            `
-    );
+  style: ({ theme, order, ...props }) => {
+    const breakpoints = Object.keys(theme.breakpoints);
+    const mediaQueries = breakpoints.map(breakpoint => {
+      if (!props[breakpoint]) {
+        return null;
+      }
+
+      if (breakpoint === 'xs') {
+        return css`
+          ${getColumnWidth(props[breakpoint], theme.gridColumns)};
+          ${props[`${breakpoint}Offset`] && getOffset(props[`${breakpoint}Offset`], theme.gridColumns)};
+        `;
+      }
+
+      return css`
+        @media (min-width: ${breakpoints[breakpoint]}px) {
+          ${getColumnWidth(props[breakpoint], theme.gridColumns)};
+          ${props[`${breakpoint}Offset`] !== undefined && getOffset(props[`${breakpoint}Offset`], theme.gridColumns)};
+        }
+      `;
+    });
 
     return css`
       box-sizing: border-box;
@@ -57,8 +62,8 @@ const StyledColumn = createComponent({
       flex-direction: column;
       padding-left: ${getPadding}px;
       padding-right: ${getPadding}px;
+      order: ${order != null ? order : 'initial'};
 
-      order: ${p.order ? p.order : 'initial'};
       ${mediaQueries};
     `;
   },

--- a/src/Grid/Column.js
+++ b/src/Grid/Column.js
@@ -35,8 +35,7 @@ const StyledColumn = createComponent({
   name: 'Column',
   as: Flex,
   style: ({ theme, order, ...props }) => {
-    const breakpoints = Object.keys(theme.breakpoints);
-    const mediaQueries = breakpoints.map(breakpoint => {
+    const mediaQueries = Object.keys(theme.breakpoints).map(breakpoint => {
       if (!props[breakpoint]) {
         return null;
       }
@@ -49,7 +48,7 @@ const StyledColumn = createComponent({
       }
 
       return css`
-        @media (min-width: ${breakpoints[breakpoint]}px) {
+        @media (min-width: ${theme.breakpoints[breakpoint]}) {
           ${getColumnWidth(props[breakpoint], theme.gridColumns)};
           ${props[`${breakpoint}Offset`] !== undefined && getOffset(props[`${breakpoint}Offset`], theme.gridColumns)};
         }
@@ -62,7 +61,6 @@ const StyledColumn = createComponent({
       flex-direction: column;
       padding-left: ${getPadding}px;
       padding-right: ${getPadding}px;
-      order: ${order != null ? order : 'initial'};
 
       ${mediaQueries};
     `;

--- a/src/Grid/Container.js
+++ b/src/Grid/Container.js
@@ -4,7 +4,7 @@ import { css } from 'styled-components';
 import Box from '../Box';
 import { createComponent } from '../utils';
 
-const getPadding = p => (typeof p.gutter === 'number' ? p.gutter / 2 : p.theme.grid.gutter / 2);
+const getPadding = p => (typeof p.gutter === 'number' ? p.gutter / 2 : p.theme.gridGutter / 2);
 
 const StyledContainer = createComponent({
   name: 'Container',
@@ -13,7 +13,7 @@ const StyledContainer = createComponent({
     margin-left: auto;
     margin-right: auto;
     width: 100%;
-    max-width: ${fluid ? '100%' : `${maxWidth || theme.grid.containerMaxWidth}px`};
+    max-width: ${fluid ? '100%' : `${maxWidth || theme.containerMaxWidth}px`};
     padding-left: ${getPadding}px;
     padding-right: ${getPadding}px;
   `,

--- a/src/Grid/Container.js
+++ b/src/Grid/Container.js
@@ -13,7 +13,7 @@ const StyledContainer = createComponent({
     margin-left: auto;
     margin-right: auto;
     width: 100%;
-    max-width: ${fluid ? '100%' : `${maxWidth || theme.containerMaxWidth}px`};
+    max-width: ${fluid ? '100%' : `${maxWidth || theme.gridWidth}px`};
     padding-left: ${getPadding}px;
     padding-right: ${getPadding}px;
   `,

--- a/src/Grid/Row.js
+++ b/src/Grid/Row.js
@@ -6,7 +6,7 @@ import { createComponent } from '../utils';
 
 const getMargin = p => {
   if (p.collapse) return 0;
-  return typeof p.gutter === 'number' ? p.gutter / 2 : p.theme.grid.gutter / 2;
+  return typeof p.gutter === 'number' ? p.gutter / 2 : p.theme.gridGutter / 2;
 };
 
 const StyledRow = createComponent({

--- a/src/Modal/Modal.dropdownExample.js
+++ b/src/Modal/Modal.dropdownExample.js
@@ -27,16 +27,10 @@ export default class ModalDropdownDemo extends React.Component {
     return (
       <div>
         <Dropdown placement="top" width={250} trigger={<Button variant="success">Open Dropdown</Button>}>
-          <Dropdown.Header title="Dropdown" />
-
-          <Dropdown.Body>
-            <Dropdown.SectionTitle>Section One</Dropdown.SectionTitle>
-            <Dropdown.Item onClick={this.toggle} as="button">
-              Open Modal
-            </Dropdown.Item>
-          </Dropdown.Body>
-
-          <Dropdown.Footer>Footer</Dropdown.Footer>
+          <Dropdown.Title>Section One</Dropdown.Title>
+          <Dropdown.Item onClick={this.toggle} as="button">
+            Open Modal
+          </Dropdown.Item>
         </Dropdown>
 
         <Modal open={this.state.isModalOpen} onClose={this.toggle} title="Example Dropdown Modal" {...props}>

--- a/src/Modal/Modal.example.js
+++ b/src/Modal/Modal.example.js
@@ -32,22 +32,14 @@ export default class ModalDemo extends React.Component {
       <div>
         <Button onClick={this.toggle}>Open Modal</Button>
 
-        <Modal
-          open={this.state.isModalOpen}
-          onClose={this.toggle}
-          title="Example Modal"
-          {...props}>
+        <Modal open={this.state.isModalOpen} onClose={this.toggle} title="Example Modal" {...props}>
           <Modal.Body>
             <>
               {body}
               <Input autoFocus name="password" label="Password" />
             </>
 
-            <Modal
-              open={this.state.isModalTwoOpen}
-              onClose={this.toggleModalTwo}
-              title="Example Modal Two"
-              {...props}>
+            <Modal open={this.state.isModalTwoOpen} onClose={this.toggleModalTwo} title="Example Modal Two" {...props}>
               <Modal.Body>{bodyTwo}</Modal.Body>
 
               <Modal.Footer>

--- a/src/Text/Text.js
+++ b/src/Text/Text.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { compose, space, color, typography } from 'styled-system';
+import propTypes from '@styled-system/prop-types';
+import { createComponent } from '../utils';
+
+const StyledText = createComponent({
+  name: 'Text',
+  tag: 'span',
+  style: compose(
+    space,
+    color,
+    typography
+  ),
+});
+
+const Text = React.forwardRef((props, ref) => <StyledText {...props} ref={ref} />);
+
+Text.propTypes = {
+  ...propTypes.typography,
+  ...propTypes.color,
+  ...propTypes.space,
+};
+
+export default Text;

--- a/src/Text/Text.spec.js
+++ b/src/Text/Text.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { renderWithTheme } from '../../test/utils';
+import Text from './Text';
+
+describe('Text', () => {
+  test('default to <span>', () => {
+    const { asFragment } = renderWithTheme(<Text>Hey!</Text>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('"as" prop', () => {
+    const { asFragment } = renderWithTheme(<Text as="h1">Hey!</Text>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('"color" prop', () => {
+    const { asFragment } = renderWithTheme(<Text color="red">Hey!</Text>);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/src/Text/Text.stories.js
+++ b/src/Text/Text.stories.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Text from './Text';
+
+export default {
+  title: 'Components|Text',
+  component: Text,
+};
+
+export const Basic = () => (
+  <>
+    <Text>The basic text component renders as a {'<span />'}</Text>
+    <Text as="h1">It can render as other tags, like this {'<H1/>'}</Text>
+    <Text color="red">It can use colors from the theme</Text>
+  </>
+);

--- a/src/Text/__snapshots__/Text.spec.js.snap
+++ b/src/Text/__snapshots__/Text.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text "as" prop 1`] = `
+<DocumentFragment>
+  <h1
+    class="re-text "
+  >
+    Hey!
+  </h1>
+</DocumentFragment>
+`;
+
+exports[`Text "color" prop 1`] = `
+<DocumentFragment>
+  .c0 {
+  color: #FD575D;
+}
+
+<span
+    class="re-text c0"
+    color="red"
+  >
+    Hey!
+  </span>
+</DocumentFragment>
+`;
+
+exports[`Text default to <span> 1`] = `
+<DocumentFragment>
+  <span
+    class="re-text "
+  >
+    Hey!
+  </span>
+</DocumentFragment>
+`;

--- a/src/Text/index.js
+++ b/src/Text/index.js
@@ -1,0 +1,3 @@
+import Text from './Text';
+
+export default Text;

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,9 @@ export Select from './Form/Select';
 export Spinner from './Spinner';
 export Switch from './Form/Switch';
 export Tabs from './Tabs';
+export Text from './Text';
 export ThemeProvider from './ThemeProvider';
 export * from './Toast';
+
 export * from './utils';
+export { default as styled, css, keyframes, createGlobalStyle } from 'styled-components';

--- a/src/theme.js
+++ b/src/theme.js
@@ -192,12 +192,13 @@ export default (overrides = {}) => {
 
   const alertVariants = badgeVariants;
 
-  const breakpoints = [480, 768, 1024, 1440];
+  const breakpoints = ['400px', '600px', '900px', '1200px', '1500px'];
   /* eslint-disable prefer-destructuring */
   breakpoints.xs = breakpoints[0];
   breakpoints.sm = breakpoints[1];
   breakpoints.md = breakpoints[2];
   breakpoints.lg = breakpoints[3];
+  breakpoints.xl = breakpoints[4];
   /* eslint-enable prefer-destructuring */
 
   return {

--- a/src/theme.js
+++ b/src/theme.js
@@ -206,7 +206,7 @@ export default (overrides = {}) => {
     space: [0, 4, 8, 16, 24, 32, 64, 126, 256],
 
     breakpoints,
-    containerMaxWidth: 1024,
+    gridWidth: 1024,
     gridGutter: 16,
     gridColumns: 12,
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,7 +1,4 @@
 export default (overrides = {}) => {
-  const shadow = '0 3px 6px hsla(0,0%,60%,.1), 0 3px 6px hsla(0,0%,60%,.15), 0 -1px 2px hsla(0,0%,60%,.02)';
-  const shadowHover = '0 6px 9px hsla(0,0%,60%,.2), 0 6px 9px hsla(0,0%,60%,.2), 0 -1px 2px hsla(0,0%,60%,.08)';
-
   const colors = Object.assign(
     {
       default: '#494D55',
@@ -58,14 +55,6 @@ export default (overrides = {}) => {
     },
     overrides.colors
   );
-
-  const radii = [0, 2, 4];
-
-  const typography = {
-    fontSize: 14,
-    bodyFontFamily: 'Avenir',
-    headerFontFamily: 'Tiempos',
-  };
 
   const buttonVariants = {
     primary: {
@@ -204,29 +193,35 @@ export default (overrides = {}) => {
   const alertVariants = badgeVariants;
 
   const breakpoints = [480, 768, 1024, 1440];
-
-  const grid = {
-    containerMaxWidth: 1000,
-    gutter: 16,
-    columns: 12,
-    sizes: {
-      xs: breakpoints[0],
-      sm: breakpoints[1],
-      md: breakpoints[2],
-      lg: breakpoints[3],
-    },
-  };
+  /* eslint-disable prefer-destructuring */
+  breakpoints.xs = breakpoints[0];
+  breakpoints.sm = breakpoints[1];
+  breakpoints.md = breakpoints[2];
+  breakpoints.lg = breakpoints[3];
+  /* eslint-enable prefer-destructuring */
 
   return {
-    breakpoints,
     classPrefix: 're',
     colors,
-    grid,
-    radii,
+    space: [0, 4, 8, 16, 24, 32, 64, 126, 256],
+
+    breakpoints,
+    containerMaxWidth: 1024,
+    gridGutter: 16,
+    gridColumns: 12,
+
+    radii: [0, 2, 4, 8],
     radius: 8,
-    shadow,
-    shadowHover,
-    typography,
+
+    shadow: '0 3px 6px hsla(0,0%,60%,.1), 0 3px 6px hsla(0,0%,60%,.15), 0 -1px 2px hsla(0,0%,60%,.02)',
+    shadowHover: '0 6px 9px hsla(0,0%,60%,.2), 0 6px 9px hsla(0,0%,60%,.2), 0 -1px 2px hsla(0,0%,60%,.08)',
+
+    typography: {
+      fontSize: 14,
+      bodyFontFamily: 'Avenir',
+      headerFontFamily: 'Tiempos',
+    },
+
     sizes: {
       Button: {
         sm: {
@@ -275,6 +270,7 @@ export default (overrides = {}) => {
         },
       },
     },
+
     variants: {
       Alert: alertVariants,
       Badge: badgeVariants,

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,4 +1,4 @@
-export default (overrides = {}) => {
+export default (customTheme = {}) => {
   const colors = Object.assign(
     {
       default: '#494D55',
@@ -53,7 +53,7 @@ export default (overrides = {}) => {
       green: '#21B986',
       greenDark: '#00AC74',
     },
-    overrides.colors
+    customTheme.colors
   );
 
   const buttonVariants = {
@@ -192,7 +192,7 @@ export default (overrides = {}) => {
 
   const alertVariants = badgeVariants;
 
-  const breakpoints = ['400px', '600px', '900px', '1200px', '1500px'];
+  const breakpoints = customTheme.breakpoints || ['400px', '600px', '900px', '1200px', '1500px'];
   /* eslint-disable prefer-destructuring */
   breakpoints.xs = breakpoints[0];
   breakpoints.sm = breakpoints[1];


### PR DESCRIPTION
## Summary

### New `<Text />` component
- `<Text as="h1" fontSize={100} color="primaryLight" />`
- Should allow us to remove many of our one-off styled components, which are typically used only to style some text


### Upgrade styled-system
- Better performance for foundational components like Box and Flex with `compose`
- Better support for responsive styles, e.g. `<Box m={{ _: 0, sm: 12 }} />`, which says for all screens, apply 0 margin, and for small screens and up, apply a 12px margin

### Clean up theme.js
- Better organization
- Remove grid nesting
- Add 24px to space scale
- Allow breakpoints to be overridden

### Clean up `<Column />`
- Remove `order` style so styled-system can apply `order` responsively, e.g. `<Column order={{ _: -1, sm: 1 }} />`
- Prettier wasn't liking some of the implicit ternary returns

### Fix Dropdown stories
- Storybook was not liking hooks in the base story
- Modal was using old Dropdown syntax