### PR TITLE
fix(Modal): Opens long-content modal at top

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -102,7 +102,7 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
           {state => (
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
               <Backdrop transitionState={state} onClick={handleBackdropClick}>
-                <ModalContent transitionState={state} onClick={handleContentClick} {...props}>
+                <ModalContent transitionState={state} onClick={handleContentClick} aria-modal="true" {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}
                 </ModalContent>
@@ -173,12 +173,25 @@ Modal.Header = ({ title, children, showClose = true }) => {
     <ModalHeader>
       <ModalHeaderInner>
         <Flex alignItems="center">
-          {title && <Modal.Title>{title}</Modal.Title>}
+          {title && (
+            <Modal.Title role="heading" tabIndex="0">
+              {title}
+            </Modal.Title>
+          )}
           {children}
 
           {showClose && (
             <Box ml="auto">
-              <Icon name="close" color="greyDarkest" style={{ cursor: 'pointer' }} size={24} onClick={handleClose} />
+              <Icon
+                name="close"
+                color="greyDarkest"
+                style={{ cursor: 'pointer' }}
+                size={24}
+                onClick={handleClose}
+                role="button"
+                aria-label="Close Modal"
+                tabIndex="0"
+              />
             </Box>
           )}
         </Flex>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -152,6 +152,7 @@ Modal.Title = createComponent({
   style: css`
     font-size: 16px;
     margin: 0;
+    outline: none;
   `,
 });
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -174,6 +174,12 @@ const ModalHeaderInner = createComponent({
 Modal.Header = ({ title, children, showClose = true }) => {
   const { handleClose } = useContext(ModalContext);
 
+  const handleKeyDown = ({ keyCode }) => {
+    if (keyCode === 13) {
+      handleClose();
+    }
+  };
+
   return (
     <ModalHeader>
       <ModalHeaderInner>
@@ -193,6 +199,7 @@ Modal.Header = ({ title, children, showClose = true }) => {
                 style={{ cursor: 'pointer' }}
                 size={24}
                 onClick={handleClose}
+                onKeyDown={handleKeyDown}
                 role="button"
                 aria-label="Close Modal"
                 tabIndex="0"

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -75,6 +75,7 @@ const ModalContent = createComponent({
 /** Modals are a great way to add dialogs to your site for lightboxes, user notifications, or completely custom content. */
 export function Modal({ children, title, animationDuration, showClose, onClose, open, ...props }) {
   const [isOpen, setOpen] = useState(open);
+  const modalRef = React.useRef(null);
 
   const handleClose = () => {
     setOpen(false);
@@ -89,6 +90,10 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
     handleClose();
   };
 
+  const scrollToTop = () => {
+    modalRef.current.scroll(0, 0);
+  };
+
   useEffect(() => {
     if (open !== isOpen) {
       setOpen(open);
@@ -98,10 +103,10 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
   return (
     <ModalContext.Provider value={{ handleClose }}>
       <Portal>
-        <Transition in={isOpen} timeout={animationDuration}>
+        <Transition in={isOpen} timeout={animationDuration} onEntering={scrollToTop}>
           {state => (
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
-              <Backdrop transitionState={state} onClick={handleBackdropClick}>
+              <Backdrop ref={modalRef} transitionState={state} onClick={handleBackdropClick}>
                 <ModalContent transitionState={state} onClick={handleContentClick} aria-modal="true" {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}


### PR DESCRIPTION
This was introduced by `react-focus-on` & it's predecessor `react-focus-lock`. It wasn't necessarily a bug since it was doing what it was intended to do, and that is to make the modal accessible. In doing so, you lock the focus into the modal, and the first item it would focus on is an input or button. This would cause the modal to open near the bottom of the scroll length. I needed to make the header accessible as well since you could not navigate to the close button via the keyboard alone.

- Adds aria roles and tabIndex to Modal Header and buttons.

## Before
![modal-middle](https://user-images.githubusercontent.com/10860014/67508530-cb4dba80-f656-11e9-857f-b60f705e5246.gif)

## After
![modal_top](https://user-images.githubusercontent.com/10860014/67508544-d0126e80-f656-11e9-8e72-a2d895e5d62e.gif)
