### PR TITLE
feat: Allow Accordion items to be open by default

### DIFF
--- a/src/Accordion/Accordion.js
+++ b/src/Accordion/Accordion.js
@@ -12,6 +12,7 @@ const AccordionItemProps = {
   content: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   renderHeader: PropTypes.func,
   renderContent: PropTypes.func,
+  isOpenByDefault: PropTypes.bool,
 };
 
 const AccordionContainer = createComponent({
@@ -99,9 +100,15 @@ export default class Accordion extends Component {
 
   static Item = AccordionItem;
 
-  state = {
-    openList: [],
-  };
+  constructor(props) {
+    super(props);
+
+    const openByDefault = props.items.map((item, index) => (item.isOpenByDefault ? index : undefined));
+
+    this.state = {
+      openList: openByDefault.filter(e => e !== undefined),
+    };
+  }
 
   handleItemToggle = idx => {
     const { solo } = this.props;

--- a/src/Accordion/Accordion.stories.js
+++ b/src/Accordion/Accordion.stories.js
@@ -1,21 +1,36 @@
 import React from 'react';
 import Accordion from './Accordion';
+import Box from '../Box';
+import Text from '../Text';
 
 export default {
   title: 'Components|Accordion',
   component: Accordion,
 };
 
+const Title = ({ children }) => <Text fontWeight={500}>{children}</Text>;
+
+const Content = ({ children }) => (
+  <Box ml={3} p={2} backgroundColor="greyLight">
+    {children}
+  </Box>
+);
+
 export const Basic = () => (
   <Accordion
     items={[
       {
-        title: 'Item One',
-        content: 'Item One Content',
+        title: <Title>Item One</Title>,
+        content: <Content>Item One Content</Content>,
       },
       {
-        title: 'Item Two',
-        content: 'Item Two Content',
+        title: <Title>Item Two</Title>,
+        content: <Content>Item Two Content</Content>,
+      },
+      {
+        title: <Title>Item Three</Title>,
+        content: <Content>I'm open by default!</Content>,
+        isOpenByDefault: true,
       },
     ]}
   />

--- a/src/Collapse/Collapse.js
+++ b/src/Collapse/Collapse.js
@@ -73,7 +73,7 @@ export default class Collapse extends Component {
 
   state = {
     isOpen: this.props.isOpen || false,
-    height: 0,
+    height: this.props.isOpen ? 'initial' : 0,
   };
 
   onEnter = (node, isAppearing) => {


### PR DESCRIPTION
## Summary 
A recent requirement came up with the patient notification update work that specifies that an accordion item needs to be open by default is a certain condition is met. So, for example, in the screenshot below, we want to keep the accordion item open only if the patient has at least one notification type enabled. 

<img width="835" alt="Screen Shot 2019-11-07 at 10 55 15 AM" src="https://user-images.githubusercontent.com/6404663/68418468-20a4c400-014d-11ea-9799-3c7cd33a6eaf.png">
