### PR TITLE
fix(Button): Remove backgroundColor from secondary variant

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -79,7 +79,6 @@ export default (customTheme = {}) => {
       },
     },
     secondary: {
-      backgroundColor: colors.white,
       borderColor: colors.primary,
       color: colors.primary,
       '&:hover': {


### PR DESCRIPTION
## Summary
Secondary button variants should not have white background by default. Doing a final pass on web's design audit and the new secondary button in GoodRx header is incorrect.

<img width="1190" alt="Screen Shot 2019-12-17 at 9 48 24 AM" src="https://user-images.githubusercontent.com/14184138/71021232-c0416480-20b2-11ea-9a5c-54f46639cefb.png">
