### PR TITLE
fix(Modal): Safeguards against onEntering error

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -91,7 +91,12 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
   };
 
   const scrollToTop = () => {
-    modalRef.current.scroll(0, 0);
+    // short delay to make sure backdrop is rendered
+    setTimeout(() => {
+      if (modalRef.current) {
+        modalRef.current.scroll(0, 0);
+      }
+    }, 1);
   };
 
   useEffect(() => {

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -91,12 +91,9 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
   };
 
   const scrollToTop = () => {
-    // short delay to make sure backdrop is rendered
-    setTimeout(() => {
-      if (modalRef.current) {
-        modalRef.current.scroll(0, 0);
-      }
-    }, 1);
+    if (modalRef.current) {
+      modalRef.current.scroll(0, 0);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
https://sentry.io/organizations/heydoctor/issues/1393699250/?referrer=slack

The modal backdrop would sometimes render after `onEntering` was called, so I wrapped in a conditional to prevent it from calling `.scroll` on the null object.