### PR TITLE
feat(Modal): Only renders modal in DOM when visible

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -6,8 +6,8 @@ import { Transition } from 'react-transition-group';
 import { FocusOn } from 'react-focus-on';
 import Portal from '../Portal';
 import Flex from '../Flex';
-import Box from '../Box';
 import Icon from '../Icon';
+import Button from '../Button';
 import { createComponent, themeGet } from '../utils';
 
 const ModalContext = createContext({});
@@ -185,27 +185,20 @@ Modal.Header = ({ title, children, showClose = true }) => {
     <ModalHeader>
       <ModalHeaderInner>
         <Flex alignItems="center">
-          {title && (
-            <Modal.Title role="heading" tabIndex="0">
-              {title}
-            </Modal.Title>
-          )}
+          {title && <Modal.Title role="heading">{title}</Modal.Title>}
           {children}
 
           {showClose && (
-            <Box ml="auto">
-              <Icon
-                name="close"
-                color="greyDarkest"
-                style={{ cursor: 'pointer' }}
-                size={24}
-                onClick={handleClose}
-                onKeyDown={handleKeyDown}
-                role="button"
-                aria-label="Close Modal"
-                tabIndex="0"
-              />
-            </Box>
+            <Button
+              variant="grey"
+              size="sm"
+              style={{ marginLeft: 'auto', border: 'none' }}
+              onClick={handleClose}
+              onKeyDown={handleKeyDown}
+              aria-label="Close Modal"
+              tabIndex="-1">
+              <Icon name="close" color="greyDarkest" size={24} />
+            </Button>
           )}
         </Flex>
       </ModalHeaderInner>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -103,7 +103,7 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
   return (
     <ModalContext.Provider value={{ handleClose }}>
       <Portal>
-        <Transition in={isOpen} timeout={animationDuration} onEntering={scrollToTop}>
+        <Transition in={isOpen} timeout={animationDuration} onEntering={scrollToTop} mountOnEnter unmountOnExit appear>
           {state => (
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
               <Backdrop ref={modalRef} transitionState={state} onClick={handleBackdropClick}>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -196,6 +196,7 @@ Modal.Header = ({ title, children, showClose = true }) => {
               onClick={handleClose}
               onKeyDown={handleKeyDown}
               aria-label="Close Modal"
+              type="button"
               tabIndex="-1">
               <Icon name="close" color="greyDarkest" size={24} />
             </Button>


### PR DESCRIPTION
This is specific to accessibility and testing in general (though it's not a change to make testing work right, this was a problem that was unearthed by testing actually).

Modals and their content were being rendered when not visible, and so readable by screen readers which would not make sense if it's not showing. Now, the modal and it's content will render when it is supposed to be visible. 🎉 

Makes the close icon a button. Also, it gives autofocus back to content.

No breaking changes.