### PR TITLE
fix(Button): Removes div from inside button

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -61,7 +61,7 @@ const StyledButton = createComponent({
 
     return css`
       position: relative;
-      display: inline-block;
+      display: inline-flex;
       cursor: pointer;
       text-transform: capitalize;
       text-align: center;
@@ -77,6 +77,8 @@ const StyledButton = createComponent({
       white-space: nowrap;
       user-select: none;
       outline: none;
+      justify-content: center;
+      align-items: center;
 
       &:before {
         transition: opacity 250ms;
@@ -139,11 +141,9 @@ const Button = React.forwardRef(
       rightIcon={rightIcon}
       colorFocus={colorFocus}
       {...rest}>
-      <Flex alignItems="center" justifyContent="center">
-        {leftIcon && renderIcon(leftIcon, leftIconProps)}
-        {children}
-        {rightIcon && renderIcon(rightIcon, rightIconProps)}
-      </Flex>
+      {leftIcon && renderIcon(leftIcon, leftIconProps)}
+      {children}
+      {rightIcon && renderIcon(rightIcon, rightIconProps)}
     </StyledButton>
   )
 );


### PR DESCRIPTION
Semantically, `div` should not be inside a button component. This removes the div and styles the button accordingly.

Source: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element