### PR TITLE
fix: set higher z-index for input labels

### DIFF
--- a/src/Form/Label.js
+++ b/src/Form/Label.js
@@ -22,6 +22,7 @@ const Label = createComponent({
         transform: ${isFloating ? 'none' : 'translateY(-50%)'};
         color: ${theme.colors.greyDarker};
         user-select: none;
+        z-index: ${isFloating ? '1' : 'auto'};
 
         &:hover {
           cursor: text;


### PR DESCRIPTION
### 📃 Summary

Fixed the hidden label issue by forcing the label to have a higher z-index than the input.

### 🏷 Asana Task

https://app.asana.com/0/1127722639002160/1156115008597897/f

### 📸 Screenshots

![Screen Shot 2020-01-08 at 12 26 36 PM](https://user-images.githubusercontent.com/978100/72013136-2af94200-3212-11ea-8191-313a907b6774.png)

### 🧪 QA

Make sure to allow Firefox to save the login credentials on the sign-in page. Log out, then go back to sign-in page.  Should look similar to screenshot above.

### 📈 Risk Analysis
🛑  Does this affect patients?
✅ Does this affect clinical?
✅ Does this mutate data?
✅ Does it touch PHI?
✅ Does it touch payments?