### PR TITLE
chore: Add build step to release script [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rollup": "rollup -c",
     "test": "jest",
     "lint": "eslint src",
-    "release": "standard-version"
+    "release": "npm run build && standard-version"
   },
   "dependencies": {
     "@styled-system/prop-types": "^5.1.2",


### PR DESCRIPTION
Running `yarn release` then publishing would not package up new code in the uploaded tarball