### PR TITLE
fix(Button): Rename internal loading prop to isLoading to remove console error

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -52,7 +52,7 @@ const StyledButton = createComponent({
     theme,
     block,
     disabled,
-    loading,
+    isLoading,
     borderRadius = theme.radius,
     colorFocus = theme.colors.colorFocus,
   }) => {
@@ -121,7 +121,7 @@ const StyledButton = createComponent({
         }
       }
 
-      ${loading && loadingCss(sizeStyles.height, variantStyles.color)};
+      ${isLoading && loadingCss(sizeStyles.height, variantStyles.color)};
       ${variantStyles}
       ${sizeStyles};
       ${space};
@@ -133,13 +133,14 @@ const renderIcon = (icon, props) => <Icon name={icon} {...props} />;
 
 /** Custom button styles for actions in forms, dialogs, and more with support for multiple sizes, states, and more. We include several predefined button styles, each serving its own semantic purpose, with a few extras thrown in for more control. */
 const Button = React.forwardRef(
-  ({ children, leftIcon, leftIconProps, rightIcon, rightIconProps, colorFocus, ...rest }, ref) => (
+  ({ children, leftIcon, leftIconProps, rightIcon, rightIconProps, colorFocus, loading, ...rest }, ref) => (
     <StyledButton
       ref={ref}
       hasText={!!children}
       leftIcon={leftIcon}
       rightIcon={rightIcon}
       colorFocus={colorFocus}
+      isLoading={loading || undefined}
       {...rest}>
       {leftIcon && renderIcon(leftIcon, leftIconProps)}
       {children}

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -140,7 +140,7 @@ const Button = React.forwardRef(
       leftIcon={leftIcon}
       rightIcon={rightIcon}
       colorFocus={colorFocus}
-      isLoading={loading || undefined}
+      isLoading={loading}
       {...rest}>
       {leftIcon && renderIcon(leftIcon, leftIconProps)}
       {children}


### PR DESCRIPTION
Tired of seeing this console error
<img width="845" alt="Screen Shot 2020-02-04 at 4 33 46 PM" src="https://user-images.githubusercontent.com/14184138/73799927-2ae65680-476c-11ea-953e-838d2be2731a.png">
