### PR TITLE
fix: Move <ModalContent> out of <Backdrop> to prevent unwanted backdrop close

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -14,9 +14,9 @@ const ModalContext = createContext({});
 
 const getAnimation = name => keyframes`${animations[name]}`;
 
-const Backdrop = createComponent({
-  name: 'ModalBackdrop',
-  style: ({ transitionState }) => css`
+const ModalContainer = createComponent({
+  name: 'ModalContainer',
+  style: css`
     top: 0;
     left: 0;
     right: 0;
@@ -28,9 +28,18 @@ const Backdrop = createComponent({
     align-items: center;
     overflow-y: auto;
     overflow-x: hidden;
-    background: rgba(0, 0, 0, 0.4);
     justify-content: center;
-
+  `,
+});
+const Backdrop = createComponent({
+  name: 'ModalBackdrop',
+  style: ({ transitionState }) => css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
     ${transitionState === 'exited' &&
       css`
         display: none;
@@ -59,7 +68,6 @@ const ModalContent = createComponent({
     background-clip: padding-box;
     box-shadow: ${theme.shadow.hard};
     border-radius: ${themeGet('radius')}px;
-    z-index: 1000;
 
     ${transitionState === 'entering' &&
       css`
@@ -109,11 +117,13 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
         <Transition in={isOpen} timeout={animationDuration} onEntering={scrollToTop} mountOnEnter unmountOnExit appear>
           {state => (
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
-              <Backdrop ref={modalRef} transitionState={state} onClick={handleBackdropClick} />
+              <ModalContainer ref={modalRef}>
+                <Backdrop transitionState={state} onClick={handleBackdropClick} />
                 <ModalContent transitionState={state} onClick={handleContentClick} aria-modal="true" {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}
                 </ModalContent>
+              </ModalContainer>
             </FocusOn>
           )}
         </Transition>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -57,8 +57,9 @@ const ModalContent = createComponent({
     max-width: ${maxWidth}px;
     background: #ffffff;
     background-clip: padding-box;
-    box-shadow: ${theme.shadow.hard});
+    box-shadow: ${theme.shadow.hard};
     border-radius: ${themeGet('radius')}px;
+    z-index: 1000;
 
     ${transitionState === 'entering' &&
       css`
@@ -108,12 +109,11 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
         <Transition in={isOpen} timeout={animationDuration} onEntering={scrollToTop} mountOnEnter unmountOnExit appear>
           {state => (
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
-              <Backdrop ref={modalRef} transitionState={state} onClick={handleBackdropClick}>
+              <Backdrop ref={modalRef} transitionState={state} onClick={handleBackdropClick} />
                 <ModalContent transitionState={state} onClick={handleContentClick} aria-modal="true" {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}
                 </ModalContent>
-              </Backdrop>
             </FocusOn>
           )}
         </Transition>


### PR DESCRIPTION
Moving the <ModalContent> out of <Backdrop> fixes this issue. I've checked that the transition animation used in <ModalContent> also applies opacity, so we don't need to reapply it despite <ModalContent> no longer being a child of <Backdrop>

This solution might also be advantageous should we later add a boolean prop to hide the backdrop. 

I also noticed that we're hardcoding z-index values, perhaps we could use library wide enum/const for z-indeces, so we can better track our z-index layering, should I create a story for this?