### PR TITLE
fix: use max-height for <ModalBody>

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -224,7 +224,7 @@ Modal.Body = createComponent({
   name: 'ModalBody',
   style: css`
     padding: 1.25rem;
-    height: calc(90vh - 105px);
+    max-height: calc(90vh - 105px);
     overflow-y: auto;
   `,
 });


### PR DESCRIPTION
Asana Task:
https://app.asana.com/0/1172458003196612/1175644854344246

Apologies, I used height instead of max-height :/ 

Current Behavior:
![Screen Shot 2020-05-13 at 12 03 16 PM](https://user-images.githubusercontent.com/11139699/81853904-f83dbe00-9511-11ea-81a0-aec1e91a6b0f.png)
Fixed Behavior:
![Screen Shot 2020-05-13 at 12 03 28 PM](https://user-images.githubusercontent.com/11139699/81853911-f96eeb00-9511-11ea-9bf3-f58e89050aca.png)
Retains Original Intent:
![Screen Shot 2020-05-13 at 12 03 35 PM](https://user-images.githubusercontent.com/11139699/81853912-fa078180-9511-11ea-818a-6095e14fb05d.png)
