### PR TITLE
chore: prevent chromatic from breaking ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest",
     "lint": "eslint src",
     "release": "npm run build && standard-version",
-    "chromatic": "chromatic"
+    "chromatic": "chromatic --exit-zero-on-changes --auto-accept-changes master"
   },
   "dependencies": {
     "@styled-system/prop-types": "^5.1.2",


### PR DESCRIPTION
📃 Summary
Setup Chromatic

Currently our GitHub checks break because chromatic exits non-zero on
changes, this means that since the changes haven't been reviewed on
chromatic, it breaks the CI and fails the rest of the checks. We don't
want this, we want the checks to continue properly, and master should be
auto-accepted as that's what the PR process is for.

Add two flags to chromatic yarn script to avoid breaking github checks
and auto-accept changes that make it to master.

🏷 Asana Task
https://app.asana.com/0/1127722595295875/1176049763317385

📸 Screenshots

🧪 QA

📈 Risk Analysis
✅ Does this affect patients?
✅ Does this affect clinical?
✅ Does this mutate data?
✅ Does it touch PHI?
✅ Does it touch payments?
✅ Does it update Node packages?