### PR TITLE
fix: Fix button padding and font sizes

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -230,19 +230,19 @@ export default (customTheme = {}) => {
     sizes: {
       Button: {
         sm: {
-          fontSize: 14,
+          fontSize: 16,
           height: 32,
-          padding: '0 12px',
+          padding: '0 8px',
         },
         md: {
           fontSize: 16,
           height: 40,
-          padding: '0 16px',
+          padding: '0 12px',
         },
         lg: {
           fontSize: 16,
           height: 48,
-          padding: '0 20px',
+          padding: '0 16px',
         },
       },
       Badge: {


### PR DESCRIPTION
### Summary 
Updates button padding and the `sm` variant font-size to match our Figma design system. This was a request from Jay when we were doing a live QA bug bash. 

**Before**
<img width="1079" alt="Screen Shot 2020-05-21 at 1 24 38 PM" src="https://user-images.githubusercontent.com/6404663/82602796-7b8c8e80-9b66-11ea-972e-1e29c54ee3d7.png">



**After**
<img width="1048" alt="Screen Shot 2020-05-21 at 1 24 53 PM" src="https://user-images.githubusercontent.com/6404663/82602803-7e877f00-9b66-11ea-932d-9c58151b419d.png">

