### PR TITLE
fix: Adjust close icon position

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -202,17 +202,17 @@ Modal.Header = ({ title, children, showClose = true }) => {
           {children}
 
           {showClose && (
-            <Button
-              variant="grey"
-              size="sm"
-              style={{ marginLeft: 'auto', border: 'none' }}
+            <Icon
+              style={{ marginLeft: 'auto', marginRight: -6, outline: 'none' }}
               onClick={handleClose}
               onKeyDown={handleKeyDown}
               aria-label="Close Modal"
-              type="button"
-              tabIndex="-1">
-              <Icon name="close" color="greyDarkest" size={24} />
-            </Button>
+              role="button"
+              tabIndex="-1"
+              name="close"
+              color="greyDarkest"
+              size={24}
+            />
           )}
         </Flex>
       </ModalHeaderInner>


### PR DESCRIPTION
### Summary 
Fixes the position of the modal close icon so that it's flush with the edge of the container. 

| Before  | After |
| ------------- | ------------- |
| <img width="353" alt="Screen Shot 2020-05-26 at 10 34 13 AM" src="https://user-images.githubusercontent.com/6404663/82932304-0e4d7480-9f3d-11ea-97d4-a981abf11218.png">  | <img width="354" alt="Screen Shot 2020-05-26 at 10 33 35 AM" src="https://user-images.githubusercontent.com/6404663/82932314-11486500-9f3d-11ea-9b8b-24861067265b.png">  |


