### PR TITLE
chore: add auto publising master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,54 @@ jobs:
     - run: npx codecov
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  publish_canary:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-node@v1
+      with:
+        registry-url: 'https://registry.npmjs.org'
+    - run: |
+        git config --global user.name 'Optimus'
+        git config --global user.email 'engineering@heydoctor.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - run: yarn install --frozen-lockfile
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: yarn build
+    - run: yarn version --new-version 0.0.0-$(echo ${{ github.sha }} | cut -c1-7)
+    - run: yarn publish . --tag canary --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish_master:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-node@v1
+      with:
+        registry-url: 'https://registry.npmjs.org'
+    - run: |
+        git config --global user.name 'Optimus'
+        git config --global user.email 'engineering@heydoctor.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+        # https://github.com/actions/checkout/issues/6
+        git checkout "${GITHUB_REF:11}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - run: yarn install --frozen-lockfile
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: npx standard-version
+    - run: git push --follow-tags origin master
+    - run: yarn build
+    - run: yarn publish . --tag latest --access public --non-interactive
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ We use [Yalc](https://github.com/whitecolor/yalc) to preview changes made to Mol
 
 ## Releasing
 
-```
-$ npm run release
-$ git push --follow-tags
-$ npm publish
-```
+Release is now automatic! As soon as you merge your branch into master it will auto build and publish.
+
+Keep in mind that to keep semantic versioning automated we must use conventional commits, eg:
+- `fix:` for patch version bumps
+- `feat:` for minor version bumps
+- `BREAKING CHANGE:` for major version bumps, this is for non backwards compatible/breaking changes!


### PR DESCRIPTION
### 📃 Summary
Adds github workflow tasks that automatically builds and publishes our
npm package. It will also build a canary version for development builds.

### 🔍 Changeset
- Update ci.yml file with new tasks
- Update readme to reflect new auto-release

### 🏷 Asana Task
https://app.asana.com/0/0/1175870752691688/f

### ↩️ Depends On

### 📸 Screenshots

### 🧪 QA
	
### 📈 Risk Analysis
- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?
- [ ] Does it update Node packages?