### PR TITLE
fix: Remove auto focus from Modal Content

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -120,7 +120,12 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
             <FocusOn onEscapeKey={handleClose} enabled={isOpen}>
               <ModalContainer ref={modalRef}>
                 <Backdrop transitionState={state} onClick={handleBackdropClick} />
-                <ModalContent transitionState={state} onClick={handleContentClick} aria-modal="true" {...props}>
+                <ModalContent
+                  transitionState={state}
+                  onClick={handleContentClick}
+                  aria-modal="true"
+                  tabIndex={0}
+                  {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}
                 </ModalContent>

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -69,6 +69,7 @@ const ModalContent = createComponent({
     box-shadow: ${theme.shadow.hard};
     border-radius: ${themeGet('radius')}px;
     max-height: 90vh;
+    outline: none;
 
     ${transitionState === 'entering' &&
       css`

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -83,7 +83,7 @@ const ModalContent = createComponent({
 });
 
 /** Modals are a great way to add dialogs to your site for lightboxes, user notifications, or completely custom content. */
-export function Modal({ children, title, animationDuration, showClose, onClose, open, ...props }) {
+export function Modal({ children, title, animationDuration, showClose, onClose, open, autofocus = false, ...props }) {
   const [isOpen, setOpen] = useState(open);
   const modalRef = React.useRef(null);
 
@@ -124,7 +124,7 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
                   transitionState={state}
                   onClick={handleContentClick}
                   aria-modal="true"
-                  tabIndex={0}
+                  tabIndex={!autofocus && 0}
                   {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -83,7 +83,7 @@ const ModalContent = createComponent({
 });
 
 /** Modals are a great way to add dialogs to your site for lightboxes, user notifications, or completely custom content. */
-export function Modal({ children, title, animationDuration, showClose, onClose, open, autofocus = false, ...props }) {
+export function Modal({ children, title, animationDuration, showClose, onClose, open, ...props }) {
   const [isOpen, setOpen] = useState(open);
   const modalRef = React.useRef(null);
 
@@ -124,7 +124,7 @@ export function Modal({ children, title, animationDuration, showClose, onClose, 
                   transitionState={state}
                   onClick={handleContentClick}
                   aria-modal="true"
-                  tabIndex={!autofocus && 0}
+                  tabIndex={0}
                   {...props}>
                   {title && <Modal.Header title={title} showClose={showClose} />}
                   {children}

--- a/src/Modal/Modal.noAutoFocusEx.js
+++ b/src/Modal/Modal.noAutoFocusEx.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import Modal from './Modal';
+import Button from '../Button';
+import Input from '../Form/Input';
+
+export default class ModalNoAutoFocusExample extends React.Component {
+  state = {
+    isModalOpen: false,
+    isModalTwoOpen: false,
+  };
+
+  toggle = () => {
+    this.setState({ isModalOpen: !this.state.isModalOpen, isModalTwoOpen: false });
+  };
+
+  toggleModalTwo = () => {
+    this.setState({ isModalTwoOpen: !this.state.isModalTwoOpen });
+  };
+
+  onCancel = () => {
+    this.toggle();
+
+    setTimeout(() => {
+      alert('Oh no! It has been canceled.');
+    }, 500);
+  };
+
+  render() {
+    const { body, bodyTwo = 'Im a nested modal!', ...props } = this.props;
+
+    return (
+      <div>
+        <Button onClick={this.toggle}>Open Modal</Button>
+
+        <Modal open={this.state.isModalOpen} onClose={this.toggle} title="Example Modal" {...props}>
+          <Modal.Body>
+            <>
+              {body}
+              <Input name="password" label="Password" />
+            </>
+
+            <Modal open={this.state.isModalTwoOpen} onClose={this.toggleModalTwo} title="Example Modal Two" {...props}>
+              <Modal.Body>{bodyTwo}</Modal.Body>
+
+              <Modal.Footer>
+                <Button.Group justifyContent="space-between">
+                  <Button variant="grey" onClick={this.toggleModalTwo}>
+                    Cancel
+                  </Button>
+                  <Button variant="success" onClick={this.toggleModalTwo}>
+                    I&apos;m Done Anyways
+                  </Button>
+                </Button.Group>
+              </Modal.Footer>
+            </Modal>
+          </Modal.Body>
+
+          <Modal.Footer>
+            <Button.Group justifyContent="space-between">
+              <Button variant="grey" onClick={this.onCancel}>
+                Cancel
+              </Button>
+              <Button variant="success" onClick={this.toggleModalTwo}>
+                Open Another Modal
+              </Button>
+            </Button.Group>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}

--- a/src/Modal/Modal.stories.js
+++ b/src/Modal/Modal.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Modal from './Modal';
 import ModalExample from './Modal.example';
 import ModalDropdownExample from './Modal.dropdownExample';
+import ModalNoAutoFocusExample from './Modal.noAutoFocusEx';
 
 export default {
   title: 'Components|Modal',
@@ -28,3 +29,5 @@ export const LongContent = () => (
 );
 
 export const DropdownTrigger = () => <ModalDropdownExample body="I'm triggered by a dropdown" />;
+
+export const NoAutoFocus = () => <ModalNoAutoFocusExample body="I'm triggered by a dropdown" />;


### PR DESCRIPTION
## 📃 Summary
1. When the Modal opens, it automatically sets focus to the first element within the ModalContent. 
This behavior can be unwanted sometimes. See discussion within the Asana ticket for more context.

**Solution**
1. We add a tabindex to the Modal component, so it does not set focus to the first element within the modal until the user presses tab.

_Important Note_
If you have a form within a modal and you want the first input to auto focus when the modal opens, then you have to pass the auto focus prop to the Input itself. 
As shown here. https://github.com/heydoctor/molekule/blob/master/src/Modal/Modal.example.js#L39

### 🏷 Asana Task
https://app.asana.com/0/1172482803331797/1176612299695449/f

QA
1. Run Molekule story book locally.
2. Check out the No Auto Focus example within the story book

Expect
When you open this modal, none of the elements should have focus until you press tab.

_I will remove this example before merging because I don't really think this needs to be an entirely separate example in our story book._
	
### 📈 Risk Analysis
- [x] Does this affect patients?
- [x] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?
- [ ] Does it update Node packages?