### PR TITLE
chore: fix chromatic missing initial build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Required for chromatic
     - uses: actions/setup-node@v1
     - run: yarn install
     - run: yarn chromatic


### PR DESCRIPTION
### 📃 Summary

This should fix the issue in which chromatic wasn't automatically making an initial build of master to compare to the PR's changes, so we had to do it manually. We need advanced AI!

### 🔍 Changeset

### 🏷 Asana Task

### ↩️ Depends On

### 📸 Screenshots

### 🧪 QA
	
### 📈 Risk Analysis
- [ ] Does this affect patients?
- [ ] Does this affect clinical?
- [ ] Does this mutate data?
- [ ] Does it touch PHI?
- [ ] Does it touch payments?
- [ ] Does it update Node packages?